### PR TITLE
German translation of documentation and minor fixes of German extension

### DIFF
--- a/Example.de.rst
+++ b/Example.de.rst
@@ -1,0 +1,166 @@
+Beispiel
+==============
+
+Unten folgen zwei Beispiele von publiccode.yml-Dateien. Das erste zeigt die Minimal-Konfiguration, die nur die zwingend erforderlichen Felder enthält, das zweite eine ausführlichere Version.
+
+
+Minimal-Konfiguration
+~~~~~~~~~~~~~~~~~~~~~
+.. code:: yaml
+
+  publiccodeYmlVersion: "0.2"
+  name: Medusaurl: "https://example.com/italia/medusa.git"softwareVersion: "dev"    # Optional releaseDate: "2017-04-15"
+  platforms:
+    - web
+  categories:
+    - financial-reporting
+  developmentStatus: development
+  softwareType: "standalone/desktop"
+  description:
+    en:
+      localisedName: medusa   # Optional
+      genericName: Text Editor
+      shortDescription: > A rather short description of the software
+      longDescription: > Very long description of this software, also split on multiple rows. You should note what the software is and why one should need it. We can potentially have many pages of text here.
+
+  features:
+      - Just one feature
+  legal:
+  license: AGPL-3.0-or-later
+  maintenance:
+  type: "community"
+
+  contacts:
+    - name: Francesco Rossi
+  localisation:
+  localisationReady: yes
+  availableLanguages:
+    - en
+
+    
+Ausführlichere Version
+~~~~~~~~~~~~~~~~~~~~~~~
+.. code:: yaml
+
+  publiccodeYmlVersion: "0.2"
+  name: Medusaapplication
+  Suite: MegaProductivitySuite
+  url: "https://example.com/italia/medusa.git"
+  landingURL: "https://example.com/italia/medusa"
+  isBasedOn: "https://github.com/italia/otello.git"
+  softwareVersion: "1.0"
+  releaseDate: "2017-04-15"
+  logo: img/logo.svgmonochromeLogo: img/logo-mono.svg
+  inputTypes:
+    - text/plainoutputTypes:
+    - text/plain
+  platforms:
+    - android
+    - ios
+  categories:
+    - content-management
+    - office
+  usedBy:
+    - Comune di Firenze
+    - Comune di Roma
+  roadmap: "https://example.com/italia/medusa/roadmap"
+  developmentStatus: development
+  softwareType: "standalone/desktop"
+  intendedAudience:
+    scope:
+      - science-and-technology
+    countries:
+      - it
+      - de
+    unsupportedCountries:
+      - us
+      
+  description:
+    en:
+      localisedName: Medusa
+      genericName: Text Editor
+    shortDescription: > This description can have a maximum of 150 characters.
+
+    longDescription: > Very long description of this software, also split on multiple rows. You should note what the software is and why one should need it.
+
+    documentation: "https://read.the.documentation/medusa/v1.0"
+    apiDocumentation: "https://read.the.api.doc/medusa/v1.0"
+
+    features:
+       - Very important feature
+       - Will run without a problem
+       - Has zero bugs
+       - Solves all the problems of the world
+    screenshots:
+       - img/sshot1.jpg
+       - img/sshot2.jpg
+       - img/sshot3.jpg
+    videos:
+       - https://youtube.com/xxxxxxxx
+    awards:
+       - 1st Price Software of the year
+       
+  legal:
+    license: AGPL-3.0-or-later
+    mainCopyrightOwner: City of Chicago
+    repoOwner: City of Chicago
+  
+  authorsFile: AUTHORS
+  
+  maintenance:
+  type: "contract"
+
+    contractors:
+      - name: "Fornitore Privato SPA"
+        email: "dario.bianchi@fornitore.it"
+        website: "https://privatecompany.com"
+        until: "2019-01-01"
+
+    contacts:
+      - name: Francesco Rossi
+        email: "francesco.rossi@comune.reggioemilia.it"
+        affiliation: Comune di Reggio Emilia
+        phone: "+3923113215112"
+        
+  localisation:
+    localisationReady: yes
+    availableLanguages:
+      - en
+      - it
+      - fr
+      - de
+      
+  dependsOn:
+    open:
+      - name: MySQL
+       versionMin: "1.1"
+        versionMax: "1.3"
+       optional: yes
+     - name: PostgreSQL
+        version: "3.2"
+        optional: yes
+   proprietary:
+      - name: Oracle
+       versionMin: "11.4"
+      - name: IBM SoftLayer
+    hardware:
+      - name: NFC Reader
+        optional: yes
+        
+  it:
+    countryExtensionVersion: "0.2"
+
+    conforme:
+      lineeGuidaDesign: yes
+      modelloInteroperabilita: yes
+      misureMinimeSicurezza: yes
+      gdpr: yes
+
+    piattaforme:
+      spid: yes
+      cie: yes
+      anpr: yes
+      pagopa: yes
+
+    riuso:
+      codiceIPA: c_h501

--- a/Readme.de.md
+++ b/Readme.de.md
@@ -1,0 +1,110 @@
+# Der publiccode.yml Standard
+
+Ein Metadaten-Deskriptions-Standard für öffentliche Software.
+
+
+>Dokumentation auf Deutsch
+
+>Read documentation in [English](https://docs.italia.it/italia/developers-italia/publiccodeyml-en/en/master/)
+
+>Leggi la documentazione in [italiano](https://docs.italia.it/italia/developers-italia/publiccodeyml/it/master/)
+
+---
+
+
+## Inhalt
+
+- [Beschreibung](#beschreibung)
+- [Funktion der Datei](#Funktion-der-Datei)
+- [Dokumentation](#Dokumentation)
+- [Projekte Finden](#Projekte-Finden)
+- [Branches](#Branches)
+- [Mitwirken](#Mitwirken)
+- [Autoren](#Autoren)
+- [Lizensierung](#Lizensierung)
+
+
+## Beschreibung
+
+Ein Metadaten-Deskriptions-Standard für öffentliche Software und Repositories, der sowohl für Entwickler als auch für Personen mit weniger technischem Hintergrund einfach zu verwenden ist, um von öffentlichen Verwaltungen und öffentlichen Organisationen entwickelte Software leicht auffindbar zu machen.
+
+
+## Funktion der Datei
+
+Viele gute Software-Projekte werden von und für die öffentliche Verwaltung entwicklt, allerdings ist die Nachnutzung dieser Projekte meist sehr begrenzt. Einige der Gründe dafür sind die geringe Auffindbarkeit und die Schwierigkeit festzustellen, welche Projekte tatsächlich innerhalb der Gegebenheiten anderer Verwaltungen funktionieren.
+Die Publiccode.yml-Datei soll diese Probleme lösen. Daher handelt es sich um eine Datei, die sowohl für Mitarbeitende der Verwaltung, die herausfinden möchten, ob sie ein Projekt nachnutzen können, leicht lesbar ist als auch für Computer. Es enthält Informationen, wie:
+
+* Den Titel und die Beschreibung des Projekts oder Produkts auf Englisch und/oder anderen Sprachen;
+
+* Den Entwicklungsstatus, z. B. Konzept, In Entwicklung, Beta, Stabil, Veraltet;
+
+* Wer sich um die Wartung kümmert und bis wann;
+
+* Wer Ansprechpartner für technische oder Support-Anfragen ist;
+
+* Für welchen nationalen und lokalen Rechtsrahmen das Projekt oder Produkt konzipiert ist;
+
+* welche Software-Abhängigkeiten dieses Projekt oder Produkt hat.
+
+Das Dateiformat Publiccode.yml soll sowohl einfach zu jedem neuen Projekt hinzugefügt werden können, als auch mit dem Projekt mitwachsen, wenn es über den ursprünglichen Rahmen, in dem es entwickelt wurde, hinaus expandiert.
+
+
+## Dokumentation
+
+Dieses Repository ist strukturiert, um mit der Docs-Italia-Plattform kompatibel zu sein. Daher wird der Inhalt der relevanten Ordner innerhalb dieser Plattform kompliliert und gerendert. Die Docs-Italia-Plattform greift auf das GitHub-Repository des Dokuments zurück, um mit verschiedenen Releases und lokalisierten Versionen umgehen zu können. Die Plattform kann als die standardmäßige Landing-Page des Projekts angesehen werden.
+
+
+## Projekte Finden
+
+Das Finden von Projekten hängt von der Struktur der Such-API der jeweiligen Hosting-Plattform ab. Zum Beispiel findet man alle Publiccode.yml-Dateien in GitHub-Dateien über eine Suche über das Frontend oder die API.
+
+    GitHub Search filename:publiccode.yml path:/
+
+Das Italienische "Digital Transformation Team" arbeitet auch daran einen Scanner zur Verfügung zu stellen, der nach alle Publiccode.yml-Dateien auf allen öffentlich zugänglichen Webseiten sucht und sie als offene Daten bereitstellt.
+
+
+## Branches
+
+Neuester Release:
+
+Alle Versionen https://github.com/italia/publiccode.yml/releases
+
+Das Projekt folgt der Sematischen Versionierung. Mehr Informationen finden Sie unter [SemVer.org](https://semver.org/).
+
+Außerdem nutzt das Projekt Branches und Tags folgendermaßen:
+
+* Der Master-Branch enthält die aktuelle stabile Version des Standards.
+
+* Der Entwicklungs-Branch enthält die vorgeschlagenen Verbesserungen für die nächste Version.
+
+* Die Release-Seite auf GitHub enthält alle veröffentlichten Versionen des Standards. Aus Gründen der Einheitlichkeit folgen Releases der Tag-Version.
+
+Da das Repository jedoch sowohl das Kernschema als auch die länderspezifischen Schemata enthält, ist es notwendig, die Versionierung weiter zu verfeinern. Daher wird jede Aktualisierung am Kern und/oder an einer länderspezifischen Erweiterung mit folgenden Tags gekennzeichnet:
+
+    core-x.y.z;cc-a.b.c
+
+Dabei steht cc für den Ländercode, der im countryExtensionVersion key definiert wird.
+
+Dieses Versionierungsschema ist grundlegend für das Projekt, da die Publiccode.yml-Datei Verweise auf den Kern-Release im publiccodeYmlVersion key enthält und jedes länderspezifische Schema einen version key enthält.
+
+Beispiele für dieses Versionsierungsschema sind:
+
+    core:0.2;it:0.4
+
+    core:0.2;fr:1.1
+
+
+
+## Mitwirken
+
+[Sie sind herzlich eingeladen Pull Requests oder Issues einzureichen](https://github.com/italia/publiccode.yml/blob/master/CONTRIBUTING.md).
+
+
+## Autoren
+
+Die Publiccode.yml-Spezifikationen werdem vom [Italian Digital Transformation Team](https://teamdigitale.governo.it/) und von den [Autoren](https://github.com/italia/publiccode.yml/blob/master/AUTHORS.md) entwickelt.
+
+
+## Lizensierung
+
+Lizensiert unter [CC-0](https://github.com/italia/publiccode.yml/blob/master/LICENSE).

--- a/categories-list.de.rst
+++ b/categories-list.de.rst
@@ -1,0 +1,204 @@
+Liste von Software-Kategorien
+=============================
+Es folgt ein festgelegtes Verzeichnis mit nützlichen Tags zur Kategorisierung der Software.
+
+Gültige Tags
+------------
+
+- accounting
+
+- agile-project-management
+
+- applicant-tracking
+
+- application-development
+
+- appointment-scheduling
+
+- backup
+
+- billing-and-invoicing
+
+- blog
+
+- budgeting
+
+- business-intelligence
+
+- business-process-management
+
+- cad
+
+- call-center-management
+
+- cloud-management
+
+- collaboration
+
+- communications
+
+- compliance-management
+
+- contact-management
+
+- content-management
+
+- crm
+
+- customer-service-and-support
+
+- data-analytics
+
+- data-collection
+
+- data-visualization
+
+- digital-asset-management
+
+- digital-citizenship
+
+- document-management
+
+- donor-management
+
+- e-commerce
+
+- e-signature
+
+- email-management
+
+- email-marketing
+
+- employee-management
+
+- enterprise-project-management
+
+- enterprise-social-networking
+
+- erp
+
+- event-management
+
+- facility-management
+
+- feedback-and-reviews-management
+
+- financial-reporting
+
+- fleet-management
+
+- fundraising
+
+- gamification
+
+- geographic-information-systems
+
+- grant-management
+
+- graphic-design
+
+- help-desk
+
+- hr
+
+- ide
+
+- identity-management
+
+- instant-messaging
+
+- inventory-management
+
+- it-asset-management
+
+- it-development
+
+- it-management
+
+- it-security
+
+- it-service-management
+
+- knowledge-management
+
+- learning-management-system
+
+- marketing
+
+- mind-mapping
+
+- mobile-marketing
+
+- mobile-payment
+
+- network-management
+
+- office
+
+- online-booking
+
+- online-community
+
+- payment-gateway
+
+- payroll
+
+- predictive-analysis
+
+- procurement
+
+- productivity-suite
+
+- project-collaboration
+
+- project-management
+
+- property-management
+
+- real-estate-management
+
+- remote-support
+
+- resource-management
+
+- sales-management
+
+- seo
+
+- service-desk
+
+- social-media-management
+
+- survey
+
+- talent-management
+
+- task-management
+
+- taxes-management
+
+- test-management
+
+- time-management
+
+- time-tracking
+
+- translation
+
+- video-conferencing
+
+- video-editing
+
+- visitor-management
+
+- voip
+
+- warehouse-management
+
+- web-collaboration
+
+- web-conferencing
+
+- website-builder
+
+- workflow-management

--- a/country.de.rst
+++ b/country.de.rst
@@ -1,0 +1,21 @@
+.. _`country-extension`:
+
+Länderspezifische Extensions
+===========================
+
+Zwar ist der Standard so strukturiert, dass er international genutzt werden kann, dennoch können Informationen eingefügt werden, die in bestimmten Ländern nützlich sind, z. B. die Angabe, dass bestimmte nationale Gesetze oder Regelungen eingehalten werden.
+
+Alle länderspezifischen Extensions sind in einer Sektion enthalten, die mit dem aus zwei Kleinbuchstaben bestehenden Ländercode gemäß `ISO 3166-1 alpha-2 country code <https://it.wikipedia.org/wiki/ISO_3166-1_alpha-2>`__ bezeichnet ist. Z. B. handelt es sich bei ``spid`` um eine Eigenschaft für italienische Software, die angibt, ob die Software in das italienische öffentliche Identifikationssystem integriert ist.
+
+Ist dies der Fall, wird dies folgendermaßen angegeben:
+
+.. code:: yaml
+
+   it:
+     countryExtensionVersion: "0.2"
+     piattaforme:
+      - spid: yes
+
+Es ist zu beachten, dass länderspezifische Extensions in internationalen Sektionen des Kerns nicht erlaubt sind. Dafür sollten länderspezifische Sektionen hinzugefügt werden.
+
+.. include:: schema.it.rst

--- a/docs/de/schema.de.rst
+++ b/docs/de/schema.de.rst
@@ -93,10 +93,10 @@ Feld ``ozg-id``
 OZG-ID: Leistung des Online Zugangsgesetzes
 
 
-Schlüssel ``leika-id``
+Feld ``leika-id``
 ''''''''''''''''''''''
 - Typ: string
-- Anzeige: optional
+- Anzeige: mandatory
 - Beispiel: 99094003140000
 
 LeiKa-Schlüssel

--- a/docs/de/schema.de.rst
+++ b/docs/de/schema.de.rst
@@ -18,10 +18,8 @@ Schlüssel ``countryExtensionVersion``
 Dieser Schlüssel gibt die Version an, an die sich das aktuelle Erweiterungsschema hält,
 aus Gründen der Vorwärtskompatibilität.
 
-Bitte beachten Sie, dass der Wert dieses Schlüssels unabhängig von dem der obersten Ebene ist
-``publiccodeYmlVersion`` ist. Auf diese Weise ist die Erweiterung
-Schema-Versionierung sowohl von der Kernversion des Schemas als auch von
-von jedem anderen Land.
+Bitte beachten Sie, dass der Wert dieses Schlüssels unabhängig von dem der obersten Ebene ``publiccodeYmlVersion`` ist. Auf diese Weise ist die Erweiterung eine
+Schema-Versionierung sowohl von der Kernversion des Schemas als auch von jedem anderen Land.
 
 
 
@@ -90,7 +88,7 @@ Feld ``ozg-id``
 - Anzeige: optional
 - Beispiel: 99094003140000
 
-OZG-ID: Leistung des Online Zugangsgesetzes
+OZG-ID: Leistung des Online-Zugangsgesetzes
 
 
 Feld ``leika-id``

--- a/forks.de.rst
+++ b/forks.de.rst
@@ -1,0 +1,62 @@
+3. Forks und Varianten
+========================
+
+Wie bereits erwähnt, kann ein Fork zwei verschiedene Formen haben, abhängig von dem letztlichen Ziel. Um zu verdeutlichen, wie die ``publiccode.yml`` in beiden Fällen zu behandeln ist, definieren wir im Folgenden zwei verschiedene Semantiken: technische Forks und Software-Varianten.
+
+Technische Forks (z.B. zur Veröffentlichung von Patches)
+--------------------------------------------------------
+
+Ein technischer Fork ist ein Fork, der von einem Entwickler zu dem Zweck gemacht wird, an der ursprünglichen Codebasis zu arbeiten oder Verbesserungen an die ursprünglichen Autoren zu senden, ohne das explizite Ziel, eine alternative Variante der ursprünglichen Software zu erstellen und zu veröffentlichen.
+
+Im Kontext von verteilten Kontrollsystemen und kollaborativen Code-Hosting-Plattformen wie GitHub wird Forking fast immer von Entwicklern als Schritt verwendet, um an einem Beitrag zu einer bestehenden Codebasis zu arbeiten, indem sie "Pull Requests" senden.
+
+Aufgrund der Art und Weise, wie Forks auf GitHub und anderen Plattformen funktionieren, veröffentlichen Entwickler ihre Forks als perfekte Kopien der ursprünglichen Software, also auch die ``publiccode.yml``. Parser müssen jedoch in der Lage sein, solche technischen Forks von der ursprünglichen Codebasis zu unterscheiden.
+
+Parser
+~~~~~~
+
+Parser **SOLLTEN** einen technischen Fork erkennen, indem sie bemerken, dass der Top-Level ``URL``-Key nicht auf das Repository verweist, in dem sich die ``publiccode.yml`` befindet.
+
+Parser **KÖNNEN** einen technischen Fork auch durch Metadaten identifizieren, die von der Code-Hosting-Plattform offengelegt werden können (z. B.: GitHub kennzeichnet Forks explizit als Forks).
+
+Autoren
+~~~~~~~
+
+Autoren von technischen Forks **SOLLTEN** die Datei ``publiccode.yml`` in keinster Weise verändern. Insbesondere **DÜRFEN** sie **NICHT** den Top-Level-``URL``-Key ändern, der weiterhin auf das ursprüngliche Repository verweisen **MUSS**.
+
+Es gibt keinen expliziten Key um einen Fork als technischen Fork zu markieren. Dies ist eine bewusste Design-Entscheidung, weil wir nicht möchten, dass die Autoren von technischen Forks die ``publiccode.yml`` kennen und notwendigerweise wissen, wie sie sie modifizieren können. Das aktuelle Design verlangt von den Autoren nicht, irgendetwas zu tun.
+
+Software-Varianten
+------------------
+
+Eine Software-Variante ist ein Fork, der als Alternative zur ursprünglichen Upstream-Software angeboten wird.
+
+Sie enthält Änderungen, die noch nicht Teil der Upstream-Version sind, wie mehr Funktionen, andere Abhängigkeiten, Optimierungen, usw.
+
+Indem ein Fork als Variante markiert wird, zeigt der Autor, dass er glaubt, dass die Variante einen vollständigen und funktionierenden Satz von Änderungen enthält, die für andere Leute nützlich sein könnten.
+
+Einen Fork als Variante zu markieren, hat **nichts** mit der Bereitschaft zu tun, einen Beitrag zum Upstream zu leisten; der Autor könnte immer noch planen, die Änderungen zum Upstream beizutragen, oder sogar gerade dabei sein, dies zu tun. Also, selbst wenn der Fork sich schließlich in den Upstream fügt, kann es sinnvoll sein, ihn während des Prozesses als Variante zu markieren, damit andere ihn entdecken und davon profitieren können.
+ 
+Parser
+~~~~~~
+
+Parser **SOLLTEN** eine Variante identifizieren, indem sie feststellen, dass der Top-Level ``URL``-Key mit dem Repository übereinstimmt, in dem die ``publiccode.yml`` gefunden wird, **UND** ein ``isBasedOn`` auf oberster Ebene existiert und auf ein anderes Repository verweist.
+
+Parser sollten andere Unterschiede in der ``publiccode.yml`` zwischen Varianten der Software voraussetzen und analysieren. Insbesondere ``description/features`` ist dazu gedacht, zwischen Varianten verglichen zu werden, um für den Benutzer sichtbare Unterschiede zu identifizieren und anzuzeigen.
+
+Autoren
+~~~~~~~
+
+Autoren, die bereit sind, einen Fork als Variante zu veröffentlichen, **MÜSSEN** mindestens:
+
+- einen Key ``isBasedOn`` hinzufügen, der auf ein oder mehrere Upstream-Repositories verweist, von denen diese Variante abgeleitet ist. 
+
+- den Wert für ``URL`` so ändern, dass er auf das Repository verweist, das die Variante enthält. 
+
+- den Wert für ``legal/repoOwner`` ändern, um auf sich selbst (die Autoren der Variante) zu verweisen. 
+
+- auf den ``Maintenance``-Abschnitt zurückkomenn, um auf den Maintenance-Status der Variante zu verweisen. 
+
+Außerdem **SOLLTEN** die Autoren die folgenden Änderungen evaluieren: 
+
+- Merkmale, die die Variante vom ``description/features``-Key unterscheiden. Bestehende Merkmale **SOLLTEN NICHT** bearbeitet oder aus dieser Liste entfernt werden, es sei denn, sie wurden aus der Variante entfernt, um Parsern einen einfachen Vergleich von Merkmalslisten zu ermöglichen. 

--- a/index.de.rst
+++ b/index.de.rst
@@ -1,0 +1,21 @@
+publiccode.yml ist ein Metadaten-Standard für Repositories, die von der italienischen öffentlichen Verwaltung entwickelte oder erworbene Software enthalten, mit dem Ziel, diese leicht auffindbar und damit für andere Stellen wiederverwendbar zu machen.
+
+Indem man eine publiccode.yml-Datei in das Stammverzeichnis eines Repositories aufnimmt und sie mit Informationen über die Software füllt, können Techniker und Beamte diese auswerten. Es können auch automatische Indizierungswerkzeuge erstellt werden, da das Format sowohl von Menschen als auch von Maschinen leicht lesbar ist.
+
+Der Standard ist so konzipiert, dass er international interoperabel ist, daher sind die länderspezifischen Schlüssel vom Kernteil getrennt und in spezifischen Abschnitten definiert, die jede Regierung festlegen kann.
+
+Zu den Informationen, die in einer publiccode.yml-Datei enthalten sind, gehören:
+
+* Name und Beschreibung des Projekts oder Produkts (in einer oder mehreren Sprachen);
+
+* Der Entwicklungsgrad (z. B. Konzept, in Entwicklung, Beta-Version, stabile Version, veraltet);
+
+* Kontaktdaten der Institution, die die Code-Basis veröffentlicht hat;
+
+* Kontaktdaten der pflegenden Institution (wenn vorhanden), inklusive des Ablaufdatums des Pflegevertrags;
+
+* Informationen über die rechtlichen Rahmenbedingungen, für die das Projekt entwickelt wurde;
+
+* Abhängigkeiten
+
+und noch viel mehr.

--- a/schema.core.de.rst
+++ b/schema.core.de.rst
@@ -1,0 +1,808 @@
+Der Standard (Kern)
+===================
+
+Dieses Dokument beschreibt das publiccode.yml-Schema.
+
+Top-Level Keys and Sections
+---------------------------
+
+Key ``publiccodeYmlVersion``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Type: string
+-  Presence: mandatory
+-  Example: ``"0.1"``
+
+This key specifies the version to which the current ``publiccode.yml``
+adheres to, for forward compatibility.
+
+Key ``name``
+~~~~~~~~~~~~
+
+-  Type: string
+-  Presence: mandatory
+-  Example: ``"Medusa"``
+
+This key contains the name of the software. It contains the (short)
+public name of the product, which can be localised in the specific
+``localisation`` section. It should be the name most people usually
+refer to the software. In case the software has both an internal “code”
+name and a commercial name, use the commercial name.
+
+Key ``applicationSuite``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Type: string
+-  Presence: optional
+-  Example: ``"MegaProductivitySuite"``
+
+This key contains the name of the “suite” to which the software belongs.
+
+Key ``url``
+~~~~~~~~~~~
+
+-  Type: string (URL)
+-  Presence: mandatory
+-  Example: ``"https://example.com/italia/medusa.git"``
+
+A unique identifier for this software. This string must be a URL to the
+source code repository (git, svn, …) in which the software is published.
+If the repository is available under multiple protocols, prefer
+HTTP/HTTPS URLs which don’t require user authentication.
+
+Forks created for the purpose of contributing upstream should not
+modify this file; this helps software parsing ``publiccode.yml`` to
+immediately skip technical forks. On the contrary, a
+complete fork that is meant to be maintained separately from the
+original software should modify this line, to give themselves the status
+of a different project.
+
+See :ref:`forks-and-variants` for a complete description of what
+is a software variant and how to handle forked software as a parser or
+an author.
+
+Key ``landingURL``
+~~~~~~~~~~~~~~~~~~
+
+-  Type: string (URL)
+-  Presence: optional
+-  Example: ``"https://example.com/italia/medusa"``
+
+If the ``url`` parameter does not serve a human readable or browsable
+page, but only serves source code to a source control client, with this
+key you have an option to specify a landing page. This page, ideally, is
+where your users will land when they will click a button labeled
+something like “Go to the application source code”. In case the product
+provides an automated graphical installer, this URL can point to a page
+which contains a reference to the source code but also offers the
+download of such an installer.
+
+Key ``isBasedOn``
+~~~~~~~~~~~~~~~~~
+
+-  Type: string or array of strings
+-  Presence: optional
+-  Example: ``"https://github.com/italia/otello.git"``
+
+In case this software is a variant or a fork of another software, which
+might or might not contain a ``publiccode.yml`` file, this key will
+contain the ``url`` of the original project(s).
+
+The existence of this key identifies the fork as a software
+variant, descending from the specified repositories.
+
+Key ``softwareVersion``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Type: string
+-  Presence: optional
+-  Example: ``"1.0"``, ``"dev"``
+
+This key contains the latest stable version number of the software. The
+version number is a string that is not meant to be interpreted and
+parsed but just displayed; parsers should not assume semantic versioning
+or any other specific version format.
+
+The key can be omitted if the software is currently in initial
+development and has never been released yet.
+
+Key ``releaseDate``
+~~~~~~~~~~~~~~~~~~~
+
+-  Type: string (date)
+-  Presence: mandatory
+-  Example: ``"2017-04-15"``
+
+This key contains the date at which the latest version was released.
+This date is mandatory if the software has been released at least once
+and thus the version number is present.
+
+Key ``logo``
+~~~~~~~~~~~~
+
+-  Type: string (relative path to file or absolute URL)
+-  Presence: optional
+-  Acceptable formats: SVG, SVGZ, PNG
+-  Example: ``"img/logo.svg"``
+
+This key contains the path to the logo of the software. Logos should be
+in vector format; raster formats are only allowed as a fallback. In this
+case, they should be transparent PNGs, minimum 1000px of width.
+The key value can be the relative path to the file starting from the root of
+the repository, or it can be an absolute URL pointing to the logo in raw
+version. In both cases, the file must reside inside the same repository where
+the ``publiccode.yml`` file is stored.
+
+Key ``monochromeLogo``
+~~~~~~~~~~~~~~~~~~~~~~
+
+-  Type: string (path to file)
+-  Presence: optional
+-  Acceptable formats: SVG, SVGZ, PNG
+-  Example: ``"img/logo-mono.svg"``
+
+A monochromatic (black) logo. The logo should be in vector format;
+raster formats are only allowed as a fallback. In this case, they should
+be transparent PNGs, minimum 1000px of width.
+The key value can be the relative path to the file starting from the root of
+the repository, or it can be an absolute URL pointing to the logo in raw
+version. In both cases, the file must reside inside the same repository where
+the ``publiccode.yml`` file is stored.
+
+Key ``inputTypes``
+~~~~~~~~~~~~~~~~~~
+
+-  Type: array of enumerated strings
+-  Presence: optional
+-  Values: as per RFC 6838
+-  Example: ``"text/plain"``
+
+A list of Media Types (MIME Types) as mandated in `RFC
+6838 <https://tools.ietf.org/html/rfc6838>`__ which the application can
+handle as input.
+
+In case the software does not support any input, you can skip this field
+or use ``application/x.empty``.
+
+Key ``outputTypes``
+~~~~~~~~~~~~~~~~~~~
+
+-  Type: array of enumerated strings
+-  Presence: optional
+-  Values: as per RFC 6838
+-  Example: ``"text/plain"``
+
+A list of Media Types (MIME Types) as mandated in `RFC
+6838 <https://tools.ietf.org/html/rfc6838>`__ which the application can
+handle as output.
+
+In case the software does not support any output, you can skip this
+field or use ``application/x.empty``.
+
+Key ``platforms``
+~~~~~~~~~~~~~~~~~
+
+-  Type: enumerated string or array of strings
+-  Presence: mandatory
+-  Values: ``web``, ``windows``, ``mac``, ``linux``, ``ios``,
+   ``android``. Human readable values outside this list are allowed.
+-  Example: ``web``
+
+This key specifies which platform the software runs on. It is meant to
+describe the platforms that users will use to access and operate the
+software, rather than the platform the software itself runs on.
+
+Use the predefined values if possible. If the software runs on a
+platform for which a predefined value is not available, a different
+value can be used.
+
+Key ``categories``
+~~~~~~~~~~~~~~~~~~
+
+-  Type: array of strings
+-  Presence: mandatory
+-  Acceptable values: see :ref:`categories-list` 
+
+A list of words that can be used to describe the software and can help
+building catalogs of open software.
+
+The controlled vocabulary :ref:`categories-list` contains the list of allowed
+values.
+
+Key ``usedBy``
+~~~~~~~~~~~~~~
+
+-  Type: array of strings
+-  Presence: optional
+
+A list of the names of prominent public administrations (that will serve
+as “testimonials”) that are currently known to the software maintainer
+to be using this software.
+
+Parsers are encouraged to enhance this list also with other information
+that can obtain independently; for instance, a fork of a software, owned
+by an administration, could be used as a signal of usage of the
+software.
+
+Key ``roadmap``
+~~~~~~~~~~~~~~~
+
+-  Type: string
+-  Presence: optional
+
+A link to a public roadmap of the software.
+
+Key ``developmentStatus``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Type: enumerated string
+-  Presence: mandatory
+-  Allowed values: ``concept``, ``development``, ``beta``, ``stable``,
+   ``obsolete``
+
+The keys are: 
+
+-  ``concept`` - The software is just a “concept”. No
+   actual code may have been produced, and the repository could simply be a
+   placeholder. 
+-  ``development`` - Some effort has gone into the
+   development of the software, but the code is not ready for the end user,
+   even in a preliminary version (beta or alpha) to be tested by end users.
+-  ``beta`` - The software is in the testing phase (alpha or beta). At
+   this stage, the software might or might not have had a preliminary
+   public release. 
+-  ``stable`` - The software has seen a first public
+   release and is ready to be used in a production environment.
+-  ``obsolete`` - The software is no longer maintained or kept up to date.
+   All of the source code is archived and kept for historical reasons.
+
+Key ``softwareType``
+~~~~~~~~~~~~~~~~~~~~
+
+-  Type: enumerated string
+-  Presence: mandatory
+-  Allowed values: ``"standalone/mobile"``, ``"standalone/iot"``,
+   ``"standalone/desktop"``, ``"standalone/web"``, ``"standalone/backend"``,
+   ``"standalone/other"``, ``"addon"``, ``"library"``, ``"configurationFiles"``
+
+The keys are:
+
+-  ``standalone/mobile`` - The software is a standalone, self-contained
+   The software is a native mobile app.
+-  ``standalone/iot`` - The software is suitable for an IoT context.
+-  ``standalone/desktop`` - The software is typically installed and run in a  
+   a desktop operating system environment.
+-  ``standalone/web`` - The software represents a web application usable by
+   means of a browser. 
+-  ``standalone/backend`` - The software is a backend application.
+-  ``standalone/other`` - The software has a different nature from the once
+   listed above.  
+-  ``softwareAddon`` - The software is an addon, such as a plugin or a
+   theme, for a more complex software (e.g. a CMS or an office suite).
+-  ``library`` - The software contains a library or an SDK to make it
+   easier to third party developers to create new products.
+-  ``configurationFiles`` - The software does not contain executable
+   script but a set of configuration files. They may document how to
+   obtain a certain deployment. They could be in the form of plain
+   configuration files, bash scripts, ansible playbooks, Dockerfiles, or
+   other instruction sets.
+
+Section ``intendedAudience``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Key ``intendedAudience/countries``
+''''''''''''''''''''''''''''''''''
+
+-  Type: array of strings
+-  Presence: optional
+
+This key explicitly includes certain countries in the intended audience,
+i.e. the software explicitly claims compliance with specific processes,
+technologies or laws. All countries are specified using lowercase ISO
+3166-1 alpha-2 two-letter country codes.
+
+Key ``intendedAudience/unsupportedCountries``
+'''''''''''''''''''''''''''''''''''''''''''''
+
+-  Type: array of strings
+-  Presence: optional
+
+This key explicitly marks countries as NOT supported. This might be the
+case if there is a conflict between how software is working and a
+specific law, process or technology. All countries are specified using
+lowercase ISO 3166-1 alpha-2 two-letter country codes.
+
+Key ``intendedAudience/scope``
+''''''''''''''''''''''''''''''
+
+-  Type: array of strings
+-  Presence: optional
+-  Acceptable values: see :ref:`scope-list` 
+
+This key contains a list of tags related to the field of application of
+the software. 
+
+Section ``description``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This section contains a general description of the software. Parsers can
+use this section for instance to create a web page describing the
+software.
+
+**Note:** since all the strings contained in this section are
+user-visible and written in a specific language, you **must** specify
+the language you are editing the text in (using the IETF 
+`BCP 47 <https://tools.ietf.org/html/bcp47>`__ specifications) by
+creating a sub-section with that name. The primary language subtag cannot be
+omitted, as mandated by the BCP 47.  
+
+An example for English:
+
+.. code:: yaml 
+
+   description:
+     en:
+       shortDescription: ...
+       longDescription: ...
+
+In the following part of the document, all keys are assumed to be in a
+sub-section with the name of the language (we will note this with
+``[lang]``).
+
+**Note:** it is mandatory to have *at least* one language in this
+section. All other languages are optional.
+
+Key ``description/[lang]/localisedName``
+''''''''''''''''''''''''''''''''''''''''
+
+-  Type: string
+-  Presence: optional
+-  Example: ``"Medusa"``
+
+This key is an opportunity to localise the name in a specific language.
+It contains the (short) public name of the product. It should be the
+name most people usually refer to the software. In case the software has
+both an internal “code” name and a commercial name, use the commercial
+name.
+
+Key ``description/[lang]/genericName``
+''''''''''''''''''''''''''''''''''''''
+
+-  Type: string (max 35 chars)
+-  Presence: mandatory
+-  Example: ``"Text Editor"``
+
+This key is the “Generic name”, which refers to the specific category to
+which the software belongs. You can usually find the generic name in the
+presentation of the software, when you write: “Software xxx is a yyy”.
+Notable examples include “Text Editor”, “Word Processor”, “Web Browser”,
+“Chat” and so on… The generic name can be up to 35 characters long.
+
+Key ``description/[lang]/shortDescription``
+'''''''''''''''''''''''''''''''''''''''''''
+
+-  Type: string (max 150 chars)
+-  Presence: mandatory
+-  Example: ``"Advanced booking system for hospitals"``
+
+This key contains a short description of the software. It should be a
+single line containing a single sentence. Maximum 150 characters are
+allowed.
+
+Key ``description/[lang]/longDescription``
+''''''''''''''''''''''''''''''''''''''''''
+
+-  Type: string (min 500 chars, max 10000 chars)
+-  Presence: mandatory (for at least one language)
+
+This key contains a longer description of the software, between 500 and
+10000 chars. It is meant to provide an overview of the capabilities of
+the software for a potential user. The audience for this text should be
+that of users of the software, not developers. You can think of this
+text as the description of the software that would be in its website (if
+the software had one).
+
+This description can contain some basic markdown: ``*italic*``,
+``**bold**``, bullet points and ``[links](#)``.
+
+Key ``description/[lang]/documentation``
+''''''''''''''''''''''''''''''''''''''''
+
+-  Type: URL
+-  Presence: optional
+
+This key contains a reference to the user-level (not developer-level)
+documentation of the software. The value must be a URL to a hosted
+version of the documentation.
+
+It is suggested that the URL points to a hosted version of the
+documentation that is immediately readable through a common web browser
+in both desktop and mobile format. The documentation should be rendered
+in HTML and browsable like a website (with a navigation index, a search
+bar, etc.).
+
+If the documentation is instead available only as a document, put a
+direct view/download link as URL in this key. You should commit the
+document as part of the source code repository, and then link to it
+using the code hosting source browser URL (e.g.: GitHub URL to the file).
+Prefer using open formats like PDF or ODT for maximum interoperability.
+
+Whichever the format for the documentation, remember to make its source
+files available under an open license, possibly by committing them as
+part of the repository itself.
+
+Key ``description/[lang]/apiDocumentation``
+'''''''''''''''''''''''''''''''''''''''''''
+
+-  Type: URL
+-  Presence: optional
+
+This key contains a reference to the API documentation of the software.
+The value must be a URL to a hosted version of the documentation.
+
+It is suggested that the URL points to a hosted version of the
+documentation that is immediately readable through a common web browser.
+The documentation should be rendered in HTML and browsable like a
+website (with a navigation index, a search bar, etc.), and if there is a
+reference or test deployment, possibly offer an interactive interface
+(e.g. Swagger).
+
+If the documentation is instead available only as a document, put a
+direct view/download link as URL in this key. You should commit the
+document as part of the source code repository, and then link to it
+using the code hosting source browser URL (e.g.: GitHub URL to the file).
+Prefer using open formats like PDF or ODT for maximum interoperability.
+
+Whichever the format for the documentation, remember to make its source
+files available under an open license, possibly by committing them as
+part of the repository itself.
+
+Key ``description/[lang]/features``
+'''''''''''''''''''''''''''''''''''
+
+-  Type: array of strings
+-  Presence: mandatory (for at least one language)
+
+This key contains a list of software features, describing what
+capabilities the software allows to do. The audience for this text
+should be that of public decision makers who will be commissioning the
+software. The features should thus not target developers; instead of
+listing technical features referring to implementation details, prefer
+listing user-visible functionalities of the software.
+
+While the key is mandatory, there is no mandatory minimum or maximum
+number of features that should be listed in this key. Each feature must
+use a maximum of 100 characters.
+
+The suggested number of features to list is between 5 and 20, depending
+on the software size and complexity. There is no need for
+exhaustiveness, as users can always read the documentation for
+additional information.
+
+Key ``description/[lang]/screenshots``
+''''''''''''''''''''''''''''''''''''''
+
+-  Type: array of strings (paths)
+-  Presence: optional
+-  Formats: PNG, JPG
+-  Example: ``"data/screenshots/configuration.png"``
+
+This key contains one or multiple paths to files showing screenshots of
+the software. They are meant to give a quick idea on how the software
+looks like and how it works.
+The key value can be the relative path to the file starting from the root of
+the repository, or it can be an absolute URL pointing to the screenshot in raw
+version. In both cases, the file must reside inside the same repository where
+the ``publiccode.yml`` file is stored.
+
+Screenshots can be of any shape and size; the suggested formats are:
+
+-  Desktop: 1280x800 @1x
+-  Tablet: 1024x768 @2x
+-  Mobile: 375x667 @2x
+
+Key ``description/[lang]/videos``
+'''''''''''''''''''''''''''''''''
+
+-  Type: array of strings (URLs)
+-  Presence: optional
+-  Example: ``"https://youtube.com/xxxxxxxx"``
+
+This key contains one or multiple URLs of videos showing how the
+software works. Like screenshots, videos should be used to give a quick
+overview on how the software looks like and how it works. Videos must be
+hosted on a video sharing website that supports the
+`oEmbed <https://oembed.com>`__ standard; popular options are YouTube
+and Vimeo.
+
+Since videos are an integral part of the documentation, it is
+recommended to publish them with an open license.
+
+Key ``description/[lang]/awards``
+'''''''''''''''''''''''''''''''''
+
+-  Type: array of strings
+-  Presence: optional
+
+A list of awards won by the software.
+
+Section ``legal``
+~~~~~~~~~~~~~~~~~
+
+Key ``legal/license``
+'''''''''''''''''''''
+
+-  Type: string
+-  Presence: mandatory
+-  Example: ``"AGPL-3.0-or-later"``
+
+This string describes the license under which the software is
+distributed. The string must contain a valid SPDX expression, referring
+to one (or multiple) open-source license. Please refer to the `SPDX
+documentation <https://spdx.org/licenses/>`__ for further information.
+
+Key ``legal/mainCopyrightOwner``
+''''''''''''''''''''''''''''''''
+
+-  Type: string
+-  Presence: optional
+-  Example: ``"City of Amsterdam"``
+
+This string describes the entity that owns the copyright on “most” of
+the code in the repository. Normally, this is the line that is reported
+with the copyright symbol at the top of most files in the repo.
+
+It is possible to list multiple owners if required so, using an English
+sentence. It is also possible to informally refer to a community of
+group of people like “Linus Torvalds and all Linux contributors”.
+
+In case it is not possible to name a main copyright owner, it is
+possible to omit this key; in those cases, if the repo has a authors
+file, you can point to it through ``legal/authorsFile``.
+
+Key ``legal/repoOwner``
+'''''''''''''''''''''''
+
+-  Type: string
+-  Presence: optional
+-  Example: ``"City of Amsterdam"``
+
+This string describes the entity that owns this repository; this might
+or might not be the same entity who owns the copyright on the code
+itself. For instance, in case of a fork of the original software, the
+``repoOwner`` is probably different from the ``mainCopyrightOwner``.
+
+Key ``legal/authorsFile``
+'''''''''''''''''''''''''
+
+-  Type: string (path to file)
+-  Presence: optional
+-  Example: ``"doc/AUTHORS.txt"``
+
+Some open-source software adopt a convention of identify the copyright
+holders through a file that lists all the entities that own the
+copyright. This is common in projects strongly backed by a community
+where there are many external contributors and no clear single/main
+copyright owner. In such cases, this key can be used to refer to the
+authors file, using a path relative to the root of the repository.
+
+Section ``maintenance``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This section provides information on the maintenance status of the
+software, useful to evaluate whether the software is actively developed
+or not.
+
+Key ``maintenance/type``
+''''''''''''''''''''''''
+
+-  Type: enumerate
+-  Presence: mandatory
+-  Values: ``"internal"``, ``"contract"``, ``"community"``, ``"none"``
+
+This key describes how the software is currently maintained.
+
+-  ``internal`` - means that the software is internally maintained by the
+   repository owner;
+-  ``contract`` - means that there is a commercial
+   contract that binds an entity to the maintenance of the software;
+-  ``community`` - means that the software is currently maintained by one
+   or more people that donate their time to the project;
+-  ``none`` - means that the software is not actively maintained.
+
+Key ``maintenance/contractors``
+'''''''''''''''''''''''''''''''
+
+-  Type: array of Contractor (see below)
+-  Presence: mandatory (if ``maintenance/type`` **is** ``contract``)
+
+This key describes the entity or entities, if any, that are currently
+contracted for maintaining the software. They can be companies,
+organizations, or other collective names.
+
+Key ``maintenance/contacts``
+''''''''''''''''''''''''''''
+
+-  Type: List of Contacts (see below)
+-  Presence: mandatory (if ``maintenance/type`` **is** ``internal`` or ``community``)
+
+One or more contacts maintaining this software.
+
+This key describes the technical people currently responsible for
+maintaining the software. All contacts need to be a physical person, not
+a company or an organisation. If somebody is acting as a representative
+of an institution, it must be listed within the ``affiliation`` of the
+contact.
+
+In case of a commercial agreement (or a chain of such agreements),
+specify the final entities actually contracted to deliver the
+maintenance. Do not specify the software owner unless it is technically
+involved with the maintenance of the product as well.
+
+Section ``localisation``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section provides an overview of the localization features of the
+software.
+
+Key ``localisation/localisationReady``
+''''''''''''''''''''''''''''''''''''''
+
+-  Type: boolean
+-  Presence: mandatory
+
+If ``yes``, the software has infrastructure in place or is otherwise
+designed to be multilingual. It does not need to be available in more
+than one language.
+
+Key ``localisation/availableLanguages``
+'''''''''''''''''''''''''''''''''''''''
+
+-  Type: list of IETF BCP 47 language tags
+-  Presence: mandatory
+-  Example: ``"it"``, ``"en"``, ``"sl-IT-nedis"``
+
+If present, this is the list of languages in which the software is
+available. Of course, this list will contain at least one language.
+The primary language subtag cannot be omitted, as mandated by the 
+`BCP 47 <https://tools.ietf.org/html/bcp47>`__.
+
+Section ``dependsOn``
+~~~~~~~~~~~~~~~~~~~~~
+
+This section provides an overview on the system-level dependencies
+required to install and use this software.
+
+**NOTE:** do not list dependencies at the source code level (e.g.:
+software libraries being used), and focus only on runtime and/or
+system-level dependencies that must be installed and maintained
+separately. For instance, a database is a good example of such
+dependencies.
+
+Key ``dependsOn/open``
+''''''''''''''''''''''
+
+-  Type: array of ``dependency`` (see below)
+-  Presence: optional
+
+This key contains a list of runtime dependencies that are distributed
+under an open-source license.
+
+Key ``dependsOn/proprietary``
+'''''''''''''''''''''''''''''
+
+-  Type: array of ``dependency`` (see below)
+-  Presence: optional
+
+This key contains a list of runtime dependencies that are distributed
+under a proprietary license.
+
+Key ``dependsOn/hardware``
+''''''''''''''''''''''''''
+
+-  Type: array of ``dependency`` (see below)
+-  Presence: optional
+
+This key contains a list of hardware dependencies that must be owned to
+use the software.
+
+Special data formats
+--------------------
+
+Dependency
+~~~~~~~~~~
+
+A ``dependency`` is a complex object. The properties are the following:
+
+-  ``name`` - **mandatory** - The name of the dependency (e.g. MySQL,
+   NFC Reader)
+-  ``versionMin`` - the first compatible version
+-  ``versionMax`` - the latest compatible version
+-  ``version`` - the only major version for which the software is
+   compatible. It assumes compatibility with all patches and bugfixes
+   later applied to this version.
+-  ``optional`` - whether the dependency is optional or mandatory
+
+Complex versioning
+~~~~~~~~~~~~~~~~~~
+
+It is of course possible to use the various keys to specify a complex
+compatibility matrix.
+
+*Ex. 1*
+
+.. code:: yaml
+
+   - name: PostgreSQL
+     version: "3.2"
+     optional: yes
+
+This snippet marks an optional dependency on PostgreSQL exactly version
+3.2.
+
+*Ex. 2*
+
+.. code:: yaml
+
+   - name: MySQL
+     versionMin: "1.1"
+     versionMax: "1.3"
+
+This snippet marks a mandatory dependency on MySQL, allowing any version
+between 1.1 and 1.3.
+
+Contact
+~~~~~~~
+
+A Contact is an object with the following properties:
+
+-  ``name`` - **mandatory** - This key contains the full name of one of
+   the technical contacts. It must be a real person; do NOT populate
+   this key with generic contact information, company departments,
+   associations, etc.
+-  ``email`` - This key contains the e-mail address of the technical
+   contact. It must be an email address of where the technical contact
+   can be directly reached; do NOT populate this key with mailing-lists
+   or generic contact points like “info@acme.inc”. The e-mail address
+   must not be obfuscated. To improve resistance against e-mail
+   collection, use ``\x64`` to replace ``@``, as allowed by the YAML
+   specification.
+-  ``phone`` - phone number (with international prefix). This has to be
+   a string. 
+-  ``affiliation`` - This key contains an explicit affiliation
+   information for the technical contact. In case of multiple
+   maintainers, this can be used to create a relation between each
+   technical contact and each maintainer entity. It can contain for
+   instance a company name, an association name, etc.
+
+Contractor
+~~~~~~~~~~
+
+A Contractor is an object with the following properties:
+
+-  ``name`` - **mandatory** - The name of the contractor, whether it’s a
+   company or a physical person.
+-  ``until`` - **mandatory** - This is a date (YYYY-MM-DD). This key
+   must contain the date at which the maintenance is going to end. In
+   case of community maintenance, the value should not be more than 2
+   years in the future, and thus will need to be regularly updated as
+   the community continues working on the project.
+-  ``email`` - This key contains the e-mail address of the technical
+   contact. It must be an email address of where the technical contact
+   can be directly reached; do NOT populate this key with mailing-lists
+   or generic contact points like “info@acme.inc”. The e-mail address
+   must not be obfuscated. To improve resistance against e-mail
+   collection, use ``\x64`` to replace ``@``, as allowed by the YAML
+   specification.
+-  ``website`` - This key points to the maintainer website. It can
+   either point to the main institutional website, or to a more
+   project-specific page or website.
+
+Datum
+~~~~~
+
+Jedes Datum in ``publiccode.yml`` muss dem Format "JJJJ-MM-TT" folgen, welches eines der Formate nach ISO8601 ist. Allerdings sind sonst keine anderen Formate aus ISO8601 für Datums-Keys erlaubt.
+
+Encodierung
+~~~~~~~~
+`publiccode.yml` **MUSS** nach UTF-8 encodiert sein.

--- a/scope-list.de.rst
+++ b/scope-list.de.rst
@@ -1,0 +1,54 @@
+Liste von Anwendungsbereichen
+=============================
+Es folgt ein festgelegtes Verzeichnis mit nützlichen Tags zur Kategorisierung der Software.
+
+Gültige Tags
+------------
+
+- agriculture
+
+- culture
+
+- defence
+
+- education
+
+- emergency-services
+
+- employment
+
+- energy
+
+- environment
+
+- finance-and-economic-development
+
+- foreign-affairs
+
+- government
+
+- healthcare
+
+- infrastructures
+
+- justice
+
+- local-authorities
+
+- manufacturing
+
+- research
+
+- science-and-technology
+
+- security
+
+- society
+
+- sport
+
+- tourism
+
+- transportation
+
+- welfare


### PR DESCRIPTION
## Title
German translation of documentation and minor fixes of German extension

## Content
We translated the documentation into German. We also did some minor fixes on the German extension.

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [ ] Italian version
- [ ] English version
- [x] German version
- [ ] Example files 
- [ ] Ask for review
