### PR TITLE
chore: make Vercel stop commenting on PRs and commits

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
Vercel comments by default on PRs and that makes GitHub send a
notication right away to the submitter, which is not really useful.

