### PR TITLE
docs(standard): specify YAML 1.2 as the file format

### DIFF
--- a/docs/standard/country.rst
+++ b/docs/standard/country.rst
@@ -22,7 +22,7 @@ If a software is compliant I will find:
    it:
      countryExtensionVersion: "1.0"
      piattaforme:
-      - spid: yes
+      - spid: true
 
 Notice that country-specific keys within international sections
 are not allowed. Countries that want to extend the format should add a

--- a/docs/standard/example/publiccode.minimal.yml
+++ b/docs/standard/example/publiccode.minimal.yml
@@ -41,6 +41,6 @@ maintenance:
     - name: Francesco Rossi
 
 localisation:
-  localisationReady: yes
+  localisationReady: true
   availableLanguages:
     - en

--- a/docs/standard/example/publiccode.yml
+++ b/docs/standard/example/publiccode.yml
@@ -95,7 +95,7 @@ maintenance:
       phone: "+3923113215112"
 
 localisation:
-  localisationReady: yes
+  localisationReady: true
   availableLanguages:
     - en
     - it
@@ -107,32 +107,32 @@ dependsOn:
     - name: MySQL
       versionMin: "1.1"
       versionMax: "1.3"
-      optional: yes
+      optional: true
     - name: PostgreSQL
       version: "3.2"
-      optional: yes
+      optional: true
   proprietary:
     - name: Oracle
       versionMin: "11.4"
     - name: IBM SoftLayer
   hardware:
     - name: NFC Reader
-      optional: yes
+      optional: true
 
 it:
   countryExtensionVersion: "0.2"
 
   conforme:
-    lineeGuidaDesign: yes
-    modelloInteroperabilita: yes
-    misureMinimeSicurezza: yes
-    gdpr: yes
+    lineeGuidaDesign: true
+    modelloInteroperabilita: true
+    misureMinimeSicurezza: true
+    gdpr: true
 
   piattaforme:
-    spid: yes
-    cie: yes
-    anpr: yes
-    pagopa: yes
+    spid: true
+    cie: true
+    anpr: true
+    pagopa: true
 
   riuso:
     codiceIPA: c_h501

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -654,7 +654,7 @@ Key ``localisation/localisationReady``
 -  Type: boolean
 -  Presence: mandatory
 
-If ``yes``, the software has infrastructure in place or is otherwise
+If ``true``, the software has infrastructure in place or is otherwise
 designed to be multilingual. It does not need to be available in more
 than one language.
 
@@ -738,7 +738,7 @@ compatibility matrix.
 
    - name: PostgreSQL
      version: "3.2"
-     optional: yes
+     optional: true
 
 This snippet marks an optional dependency on PostgreSQL exactly version
 3.2.
@@ -810,4 +810,5 @@ format though, so not the full ISO8601 is allowed for the date keys.
 
 Encoding
 ~~~~~~~~
-`publiccode.yml` **MUST** be UTF-8 encoded.
+`publiccode.yml` **MUST** be a UTF-8 encoded and **SHOULD** be a YAML 1.2 document,
+using YAML 1.1 is *deprecated*.

--- a/docs/standard/schema.it.rst
+++ b/docs/standard/schema.it.rst
@@ -32,7 +32,7 @@ Key ``conforme/lineeGuidaDesign``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software is compliant with the Italian accessibility
+If present and set to ``true``, the software is compliant with the Italian accessibility
 laws (L. 4/2004), as further explained in the 
 `linee guida di
 design <https://docs.italia.it/italia/designers-italia/design-linee-guida-docs>`__ (Italian language).
@@ -43,7 +43,7 @@ Key ``conforme/modelloInteroperatibilita``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software is compliant with the `linee
+If present and set to ``true``, the software is compliant with the `linee
 guida
 sull’interoperabilità <https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs>`__.
 
@@ -57,7 +57,7 @@ Key ``conforme/misureMinimeSicurezza``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software is compliant with the `Misure
+If present and set to ``true``, the software is compliant with the `Misure
 minime di sicurezza ICT per le Pubbliche
 amministrazioni <https://www.agid.gov.it/it/sicurezza/misure-minime-sicurezza-ict>`__ (Italian language).
 
@@ -68,7 +68,7 @@ Key ``conforme/gdpr``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software respects the GDPR.
+If present and set to ``true``, the software respects the GDPR.
 
 
 Section ``piattaforme``
@@ -81,7 +81,7 @@ Key ``piattaforme/spid``
 - Presence: optional
 
 
-If present and set to ``yes``, the software interfaces with `SPID
+If present and set to ``true``, the software interfaces with `SPID
 - il Sistema Pubblico di Identità
 Digitale <https://developers.italia.it/it/spid>`__.
 
@@ -91,7 +91,7 @@ Key ``piattaforme/cie``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software interfaces with the Italian
+If present and set to ``true``, the software interfaces with the Italian
 electronic ID card (``Carta di Identità Elettronica``).
 
 Key ``piattaforme/anpr``
@@ -100,7 +100,7 @@ Key ``piattaforme/anpr``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software interfaces with ANPR.
+If present and set to ``true``, the software interfaces with ANPR.
 
 Key ``piattafome/pagopa``
 '''''''''''''''''''''''''
@@ -108,7 +108,7 @@ Key ``piattafome/pagopa``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software interfaces with pagoPA.
+If present and set to ``true``, the software interfaces with pagoPA.
 
 Section ``riuso``
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As discussed in https://github.com/publiccodeyml/publiccode.yml/discussions/115

@remcohaszing wrote:
> This specification defines a YAML file which should use yes/no is accepted in several places. However, the meaning of yes/no is ambiguous in YAML. In YAML 1.1 and older [these values represent booleans](https://yaml.org/type/bool.html), but in YAML 1.2 [they don’t](https://yaml.org/spec/1.2.0/#id2602744), meaning they represent strings.
>
> I suggest to remove this ambiguity by changing them to unambigous booleans (true/false) in the specification.