### PR TITLE
docs(standard): deprecate monochromeLogo

### DIFF
--- a/docs/standard/example/publiccode.yml
+++ b/docs/standard/example/publiccode.yml
@@ -8,7 +8,6 @@ isBasedOn: "https://github.com/italia/otello.git"
 softwareVersion: "1.0"
 releaseDate: "2017-04-15"
 logo: img/logo.svg
-monochromeLogo: img/logo-mono.svg
 
 inputTypes:
   - text/plain

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -136,8 +136,8 @@ the repository, or it can be an absolute URL pointing to the logo in raw
 version. In both cases, the file must reside inside the same repository where
 the ``publiccode.yml`` file is stored.
 
-Key ``monochromeLogo``
-~~~~~~~~~~~~~~~~~~~~~~
+Key ``monochromeLogo`` (*deprecated*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Type: string (path to file)
 -  Presence: optional


### PR DESCRIPTION
monochromeLogo is rarely used and rarely useful and the monochrome version
can always be obtained from main logo.

Fix #66.

