### PR TITLE
docs(standard): make genericName optional and deprecate it

### DIFF
--- a/docs/standard/example/publiccode.minimal.yml
+++ b/docs/standard/example/publiccode.minimal.yml
@@ -17,7 +17,6 @@ softwareType: "standalone/desktop"
 description:
   en:
     localisedName: medusa   # Optional
-    genericName: Text Editor
     shortDescription: >
           A rather short description which
           is probably useless

--- a/docs/standard/example/publiccode.yml
+++ b/docs/standard/example/publiccode.yml
@@ -45,7 +45,6 @@ intendedAudience:
 description:
   en:
     localisedName: Medusa
-    genericName: Text Editor
     shortDescription: >
           This description can have a maximum 150
           characters long. We should not fill the

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -368,11 +368,11 @@ name most people usually refer to the software. In case the software has
 both an internal “code” name and a commercial name, use the commercial
 name.
 
-Key ``description/[lang]/genericName``
-''''''''''''''''''''''''''''''''''''''
+Key ``description/[lang]/genericName`` (*deprecated*)
+'''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 -  Type: string (max 35 chars)
--  Presence: mandatory
+-  Presence: optional
 -  Example: ``"Text Editor"``
 
 This key is the “Generic name”, which refers to the specific category to


### PR DESCRIPTION
genericName doesn't really fit software outside Desktop environments
and is often misused in practice. Also, we don't offer any controlled vocabulary
for generic names.

The 'shortDescription' and 'name' keys are good enough.

Fix #59.

