### PR TITLE
docs(standard): deprecate inputTypes and outputTypes

### DIFF
--- a/docs/standard/example/publiccode.yml
+++ b/docs/standard/example/publiccode.yml
@@ -10,11 +10,6 @@ releaseDate: "2017-04-15"
 logo: img/logo.svg
 monochromeLogo: img/logo-mono.svg
 
-inputTypes:
-  - text/plain
-outputTypes:
-  - text/plain
-
 platforms:
   - android
   - ios

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -152,8 +152,8 @@ the repository, or it can be an absolute URL pointing to the logo in raw
 version. In both cases, the file must reside inside the same repository where
 the ``publiccode.yml`` file is stored.
 
-Key ``inputTypes``
-~~~~~~~~~~~~~~~~~~
+Key ``inputTypes`` (*deprecated*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Type: array of enumerated strings
 -  Presence: optional
@@ -167,8 +167,8 @@ handle as input.
 In case the software does not support any input, you can skip this field
 or use ``application/x.empty``.
 
-Key ``outputTypes``
-~~~~~~~~~~~~~~~~~~~
+Key ``outputTypes`` (*deprecated*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Type: array of enumerated strings
 -  Presence: optional


### PR DESCRIPTION
As discussed in https://github.com/publiccodeyml/publiccode.yml/discussions/122#discussioncomment-1835681
> @bfabio
> I've always felt that {input,output}Types were influenced by [Desktop files](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html)
>
> In general, that's a pretty desktop-centric key that is not really all that relevant besides for softwareType: standalone/desktop,  and even for those applications brings a little value and is deemed not worth to keep updated. That's a guaranteed for  incomplete information.
>
> Case in point: not a single publiccode.yml in the Italian software catalog uses it.
>
> IMO we should just deprecate it.