### PR TITLE
chore: fix the preview build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Sphinx==4.3.1
 sphinx-press-theme==0.8.0
+urllib3==1.26.6


### PR DESCRIPTION
The preview build fails because of
https://github.com/readthedocs/readthedocs.org/issues/10290, let's pin urllib3 to workaround that.

