### PR TITLE
Make "releaseDate" key an optional key

### DIFF
--- a/docs/de/schema.core.rst
+++ b/docs/de/schema.core.rst
@@ -114,8 +114,6 @@ Key ``releaseDate``
 -  Example: ``"2017-04-15"``
 
 This key contains the date at which the latest version was released.
-This date is mandatory if the software has been released at least once
-and thus the version number is present.
 
 Key ``logo``
 ~~~~~~~~~~~~

--- a/docs/de/schema.core.rst
+++ b/docs/de/schema.core.rst
@@ -110,7 +110,7 @@ Key ``releaseDate``
 ~~~~~~~~~~~~~~~~~~~
 
 -  Type: string (date)
--  Presence: mandatory
+-  Presence: optional
 -  Example: ``"2017-04-15"``
 
 This key contains the date at which the latest version was released.

--- a/docs/fr/schema.core.rst
+++ b/docs/fr/schema.core.rst
@@ -112,7 +112,7 @@ Clé ``releaseDate``
 ~~~~~~~~~~~~~~~~~~~
 
 -  Type: chaîne de caractères (date)
--  Présence: obligatoire
+-  Présence: facultative
 -  Exemple: ``"2017-04-15"``
 
 Cette clé contient la date à laquelle la dernière version a été publiée. Cette

--- a/docs/fr/schema.core.rst
+++ b/docs/fr/schema.core.rst
@@ -115,9 +115,7 @@ Clé ``releaseDate``
 -  Présence: facultative
 -  Exemple: ``"2017-04-15"``
 
-Cette clé contient la date à laquelle la dernière version a été publiée. Cette
-date est obligatoire si le logiciel a été publié au moins une fois et qu'il
-existe, par conséquent, un numéro de version.
+Cette clé contient la date à laquelle la dernière version a été publiée.
 
 Clé ``logo``
 ~~~~~~~~~~~~

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -124,9 +124,7 @@ Chiave ``releaseDate``
 -  Presenza: opzionale
 -  Esempio: ``"2017-04-15"``
 
-Questa chiave contiene la data di ultimo rilascio del software. Questa
-data è obbligatoria se il software è stato rilasciato almeno una volta e
-dunque esiste un numero di versione.
+Questa chiave contiene la data di ultimo rilascio del software.
 
 Chiave ``logo``
 ~~~~~~~~~~~~~~~

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -121,7 +121,7 @@ Chiave ``releaseDate``
 ~~~~~~~~~~~~~~~~~~~~~~
 
 -  Tipo: stringa (data)
--  Presenza: obbligatoria
+-  Presenza: opzionale
 -  Esempio: ``"2017-04-15"``
 
 Questa chiave contiene la data di ultimo rilascio del software. Questa

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -117,8 +117,6 @@ Key ``releaseDate``
 -  Example: ``"2017-04-15"``
 
 This key contains the date at which the latest version was released.
-This date is only mandatory if the software has been released at least once
-and thus the version number is present.
 
 Key ``logo``
 ~~~~~~~~~~~~

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -113,11 +113,11 @@ Key ``releaseDate``
 ~~~~~~~~~~~~~~~~~~~
 
 -  Type: string (date)
--  Presence: mandatory
+-  Presence: optional
 -  Example: ``"2017-04-15"``
 
 This key contains the date at which the latest version was released.
-This date is mandatory if the software has been released at least once
+This date is only mandatory if the software has been released at least once
 and thus the version number is present.
 
 Key ``logo``


### PR DESCRIPTION
As stated in the following [thread](https://github.com/publiccodeyml/publiccode.yml/discussions/114#discussioncomment-1787018). It would be logical to make the `releaseDate` key optional.

Main reasons that can be coined for this are: 
- Some repositories don't use release tags (SemVer). These repo's don't have a logical release date. In practice a lot of repositories will use Continuous Delivery and for these this will be the case.
- It could be argued that it is undesirable if the publiccode.yml becomes a file that has to be updated very often. In the case of developer.overheid.nl we can also fetch the date of the last release via the Gitlab/Github API.