### PR TITLE
doc(standard): deprecate usedBy

### DIFF
--- a/docs/de/schema.core.rst
+++ b/docs/de/schema.core.rst
@@ -209,8 +209,8 @@ building catalogs of open software.
 The controlled vocabulary :ref:`categories-list` contains the list of allowed
 values.
 
-Key ``usedBy``
-~~~~~~~~~~~~~~
+Key ``usedBy`` (*deprecated*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Type: array of strings
 -  Presence: optional

--- a/docs/fr/schema.core.rst
+++ b/docs/fr/schema.core.rst
@@ -216,8 +216,8 @@ et aider à la constitution d'un catalogue des logiciels ouverts.
 Le vocabulaire contrôlé de la :ref:`categories-list` présente la liste
 des valeurs acceptées.
 
-Clé ``usedBy``
-~~~~~~~~~~~~~~
+Clé ``usedBy`` (*deprecated*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Type: array de chaînes de caractères
 -  Présence: facultative

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -223,8 +223,8 @@ e possono aiutare a costruire il catalogo di software open.
 Il vocabolario controllato :ref:`categories-list` presenta la lista dei valori
 accettabili. 
 
-Chiave ``usedBy``
-~~~~~~~~~~~~~~~~~
+Chiave ``usedBy`` (*deprecated*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Tipo: array di stringhe
 -  Presenza: opzionale

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -212,8 +212,8 @@ building catalogs of open software.
 The controlled vocabulary :ref:`categories-list` contains the list of allowed
 values.
 
-Key ``usedBy``
-~~~~~~~~~~~~~~
+Key ``usedBy`` (*deprecated*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Type: array of strings
 -  Presence: optional


### PR DESCRIPTION
So, here are the raw points I collected over the years. I can expand on each of them if needed:

* Nothing proves the person opening the PR is who they claim to be, nor that the named PA actually uses the software
* The process is hostile to normal users:
  * a PR is alien to non technical people
  * it requires an account on the hosting platform, typically GitHub but not only
  * the maintainer can be unresponsive and never merge (happens a lot)
  * PRs can be disabled altogether
* When the person who added one leaves the PA, the knowledge leaves with them and nobody will ever remove it.
* The maintainer is a bad gatekeeper and they have a conflict of interest: a longer list means satisfaction and promotion, and they can edit the list themselves if they want.
* Removal is done even less diligently than addition (ie. never done).
* It is free text: no established format for the entity names, no Europe wide registry to normalize them (at best country level ones, all different), so entries cannot be joined or analyzed programmatically.
* I think the right layer is the catalog level, typically managed by each country (or a local entity anyway). They can define their controlled vocabulary of PAs.

As a substitute for the key, I propose: [open-catalog-api](https://github.com/publiccodeyml/open-catalog-api) adds a  `usedBy` field to `/v1/software`:
  * a catalog can authenticate users, possibly recognizing them as PA employees through the national identity and attribute systems, which solves the identity problem
  * declaring usage is a checkbox, much easier than a PR that may never be merged
  * removing yourself is one click too
  * bonus: an inventory of the software each PA uses, something Italy for example asks for periodically

And one last thought experiment supporting it doesn't work: important software should have a publiccode.yml right? Give Firefox one and a truthful `usedBy` holds tens of thousands of entries. What protects the key today is that nobody fills it exhaustively: a field that has to stay incomplete to look useful.

Fix #61.