### PR TITLE
fix: wrong key in `softwareType` description

### DIFF
--- a/docs/de/schema.core.rst
+++ b/docs/de/schema.core.rst
@@ -275,7 +275,7 @@ The keys are:
 -  ``standalone/backend`` - The software is a backend application.
 -  ``standalone/other`` - The software has a different nature from the once
    listed above.  
--  ``softwareAddon`` - The software is an addon, such as a plugin or a
+-  ``addon`` - The software is an addon, such as a plugin or a
    theme, for a more complex software (e.g. a CMS or an office suite).
 -  ``library`` - The software contains a library or an SDK to make it
    easier to third party developers to create new products.

--- a/docs/fr/schema.core.rst
+++ b/docs/fr/schema.core.rst
@@ -283,7 +283,7 @@ utilisable au moyen d’un navigateur.
 -  ``standalone/backend`` - Le logiciel est une application backend.
 -  ``standalone/other`` - Le logiciel a une nature différente de ceux
 listés ci-dessus.  
--  ``softwareAddon`` - Le software est un addon, tel qu'un plugin
+-  ``addon`` - Le software est un addon, tel qu'un plugin
 ou un thème, dans le cadre de logiciel plus complexe (ex. un CMS ou
 une suite bureautique).
 -  ``library`` - Le logiciel contient une bibliothèque ou un SDK

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -290,7 +290,7 @@ Le chiavi sono:
 -  ``standalone/backend`` - Il software è un applicativo backend. 
 -  ``standalone/other``  - Il software ha una natura diversa rispetto a quanto
    specificato alle chiavi precedenti. 
--  ``softwareAddon`` - Il software è un *addon*,
+-  ``addon`` - Il software è un *addon*,
    come ad esempio un plugin o un tema, per un software più complesso
    (e.g., un CMS o una suite per ufficio). 
 -  ``library`` - Il software

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -278,7 +278,7 @@ The keys are:
 -  ``standalone/backend`` - The software is a backend application.
 -  ``standalone/other`` - The software has a different nature from the once
    listed above.  
--  ``softwareAddon`` - The software is an addon, such as a plugin or a
+-  ``addon`` - The software is an addon, such as a plugin or a
    theme, for a more complex software (e.g. a CMS or an office suite).
 -  ``library`` - The software contains a library or an SDK to make it
    easier to third party developers to create new products.


### PR DESCRIPTION
The key description in `softwareType` had a wrong key, the right one is correctly listed in the Allowed values as `addon`.

