### PR TITLE
fix: embarrassing and long-standing typo in Italian section

### DIFF
--- a/docs/fr/schema.it.rst
+++ b/docs/fr/schema.it.rst
@@ -43,8 +43,8 @@ laws (L. 4/2004), as further explained in the
 `linee guida di
 design <https://docs.italia.it/italia/designers-italia/design-linee-guida-docs>`__ (Italian language).
 
-Key ``conforme/modelloInteroperatibilita``
-''''''''''''''''''''''''''''''''''''''''''
+Key ``conforme/modelloInteroperabilita``
+''''''''''''''''''''''''''''''''''''''''
 
 - Type: boolean
 - Presence: optional

--- a/docs/standard/schema.it.rst
+++ b/docs/standard/schema.it.rst
@@ -37,8 +37,8 @@ laws (L. 4/2004), as further explained in the
 `linee guida di
 design <https://docs.italia.it/italia/designers-italia/design-linee-guida-docs>`__ (Italian language).
 
-Key ``conforme/modelloInteroperatibilita``
-''''''''''''''''''''''''''''''''''''''''''
+Key ``conforme/modelloInteroperabilita``
+''''''''''''''''''''''''''''''''''''''''
 
 - Type: boolean
 - Presence: optional


### PR DESCRIPTION
The key was always supposed to be `modelloInteroperabilita` and the example had the correct spelling.

The tooling always checked for the right spelling, though.

