### PR TITLE
Mention opencode.de

### DIFF
--- a/docs/standard/index.rst
+++ b/docs/standard/index.rst
@@ -13,8 +13,10 @@ format is easily readable by both humans and machines.
 ``publiccode.yml`` is mandatory for all public software developed in Italy,
 according to the national `guidelines
 <https://docs.italia.it/AgID/linee-guida-riuso-software/lg-acquisizione-e-riuso-software-per-pa-docs/>`__:
-this enables the Developers Italia crawler to build the national `software
-catalog <https://developers.italia.it/>`__. The standard is designed to be
+this enables the Developers Italia crawler to build the `national software
+catalog <https://developers.italia.it/>`__. The standard is also used at
+`opencode.de <https://opencode.de>`__, the German registry of open source for
+public administration. ``publiccode.yml`` is designed to be
 interoperable internationally, thus the country-specific keys are separated by
 the core part and are defined in specific sections that each government can
 rule.


### PR DESCRIPTION
The German registry of open source for public administration also uses publiccode.yml, see https://wikijs.opencode.de/de/Hilfestellungen_und_Richtlinien/Leitlinien

