### PR TITLE
Added Github links to navbar/ footer to hopefully increase contributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Thumbs.db
 
 # Swap files
 *.swp
+
+# Sphinx
+build

--- a/README.md
+++ b/README.md
@@ -90,3 +90,22 @@ Feel free to submit [Pull Requests and to file Issues](CONTRIBUTING.md).
 ## Licence
 
 Licenced under the [CC0-1.0](LICENSE).
+
+## Development
+The documentation website about the Publiccode standard is built using the Python Sphinx package.
+
+### Prerequisites
+- A version of python3
+
+### Install dependencies
+
+```
+pip install -r requirements.txt
+```
+
+### Local development process
+`spinx-build` can be used to compile all source file to static html files. Run this command to generate the website:
+```
+sphinx-build docs/standard build -c .
+```
+

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,0 +1,32 @@
+{% extends '!layout.html' %}
+
+{% block footer %}
+
+<div class="footer">
+    <p>© Copyright <a href="https://github.com/publiccodeyml/publiccode.yml/blob/main/AUTHORS.md">publiccode.yml authors</a> <span style="margin-left:8px; margin-right: 8px;">|</span> <a href="https://github.com/publiccodeyml/publiccode.yml">Github</a></p>
+</div>
+
+{% endblock %}
+
+{% block header %}
+
+<header class="navbar">
+    <div class="sidebar-button">
+        <svg class="icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="M436 124H12c-6.627 0-12-5.373-12-12V80c0-6.627 5.373-12 12-12h424c6.627 0 12 5.373 12 12v32c0 6.627-5.373 12-12 12zm0 160H12c-6.627 0-12-5.373-12-12v-32c0-6.627 5.373-12 12-12h424c6.627 0 12 5.373 12 12v32c0 6.627-5.373 12-12 12zm0 160H12c-6.627 0-12-5.373-12-12v-32c0-6.627 5.373-12 12-12h424c6.627 0 12 5.373 12 12v32c0 6.627-5.373 12-12 12z" class=""></path>
+        </svg>
+    </div>
+    <a href="index.html" class="home-link">
+        <span class="site-name">{{ project }}</span>
+    </a>
+</a>
+    <a href="index.html" style="float: right; margin-top: 1px;">
+        <svg height="32" aria-hidden="true" viewBox="0 0 24 24" version="1.1" width="32" data-view-component="true">
+            <path fill="#2c3e50" d="M12.5.75C6.146.75 1 5.896 1 12.25c0 5.089 3.292 9.387 7.863 10.91.575.101.79-.244.79-.546 0-.273-.014-1.178-.014-2.142-2.889.532-3.636-.704-3.866-1.35-.13-.331-.69-1.352-1.18-1.625-.402-.216-.977-.748-.014-.762.906-.014 1.553.834 1.769 1.179 1.035 1.74 2.688 1.25 3.349.948.1-.747.402-1.25.733-1.538-2.559-.287-5.232-1.279-5.232-5.678 0-1.25.445-2.285 1.178-3.09-.115-.288-.517-1.467.115-3.048 0 0 .963-.302 3.163 1.179.92-.259 1.897-.388 2.875-.388.977 0 1.955.13 2.875.388 2.2-1.495 3.162-1.179 3.162-1.179.633 1.581.23 2.76.115 3.048.733.805 1.179 1.825 1.179 3.09 0 4.413-2.688 5.39-5.247 5.678.417.36.776 1.05.776 2.128 0 1.538-.014 2.774-.014 3.162 0 .302.216.662.79.547C20.709 21.637 24 17.324 24 12.25 24 5.896 18.854.75 12.5.75Z"></path>
+        </svg>
+    </a>
+    <div class="links">
+        <nav class="nav-links can-hide"></nav>
+    </div>
+</header>
+
+{% endblock %}

--- a/conf.py
+++ b/conf.py
@@ -15,6 +15,8 @@ project = "publiccode.yml Standard (v0.4.0)"
 
 html_theme = "press"
 
+templates_path = ['_templates']
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',


### PR DESCRIPTION
I created this PR for two reasons;

- I wanted to contribute to this project because im very much involved in the mission to make Open Source more discoverable.
- I realized, that as soon as you arrive on https://yml.publiccode.tools/, its tough to find the source code and find out if you can contribute. Despite it is actually fairly easy to contribute to this standard. 

I added three things i added in this PR:

**Github logo with link to repo in navbar**
![Screenshot from 2024-11-20 08-50-53](https://github.com/user-attachments/assets/ba2f62e9-9335-4c7c-9679-e4e3e16a2a14)

**Link to Authors.md in footer + link to Github again**
![Screenshot from 2024-11-20 08-50-32](https://github.com/user-attachments/assets/864c8176-9d61-4b89-a283-c3224d8036e5)

**Added info to readme.md on how to develop locally **
This answers the question immediately, that the website is build on Sphinx.
