### PR TITLE
Clarify presence rules for `contractors` and `contacts`

### DIFF
--- a/docs/de/schema.core.rst
+++ b/docs/de/schema.core.rst
@@ -612,7 +612,7 @@ Key ``maintenance/contractors``
 '''''''''''''''''''''''''''''''
 
 -  Type: array of Contractor (see below)
--  Presence: mandatory (if ``maintenance/type`` **is** ``contract``)
+-  Presence: mandatory if ``maintenance/type`` **is** ``contract``; must not be present otherwise
 
 This key describes the entity or entities, if any, that are currently
 contracted for maintaining the software. They can be companies,
@@ -622,7 +622,7 @@ Key ``maintenance/contacts``
 ''''''''''''''''''''''''''''
 
 -  Type: List of Contacts (see below)
--  Presence: mandatory (if ``maintenance/type`` **is** ``internal`` or ``community``)
+-  Presence: mandatory if ``maintenance/type`` **is** ``internal`` or ``community``; optional otherwise
 
 One or more contacts maintaining this software.
 

--- a/docs/fr/schema.core.rst
+++ b/docs/fr/schema.core.rst
@@ -625,7 +625,7 @@ Clé ``maintenance/contractors``
 '''''''''''''''''''''''''''''''
 
 -  Type: array of Contractor (voir ci-dessous)
--  Présence: obligatoire (si ``maintenance/type`` **est** ``contract``)
+-  Présence: obligatoire si ``maintenance/type`` **est** ``contract``; ne doit pas être présent dans les autres cas
 
 Cette clé décrit la ou les entités actuellement sous contrat pour la maintenance du logiciel. Il peut s'agir d'entreprises, d'organisations ou d'autres collectifs.
 
@@ -633,7 +633,7 @@ Clé ``maintenance/contacts``
 ''''''''''''''''''''''''''''
 
 -  Type: Liste des Contacts (voir ci-dessous)
--  Présence: obligatoire (si ``maintenance/type`` **est** ``internal`` ou ``community``)
+-  Présence: obligatoire si ``maintenance/type`` **est** ``internal`` ou ``community``; facultatif dans les autres cas
 
 Un ou plusieurs contacts assurant la maintenance du logiciel. 
 

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -654,7 +654,7 @@ Chiave ``maintenance/contractors``
 ''''''''''''''''''''''''''''''''''
 
 -  Tipo: array di Contractor (vedi sotto)
--  Presenza: obbligatoria (se ``maintenance/type`` **è** ``contract``)
+-  Presenza: obbligatoria se ``maintenance/type`` **è** ``contract``; non deve essere presente negli altri casi
 
 Questa chiave descrive l’entità o le entità, se ce ne sono, che
 attualmente hanno un contratto di manutenzione del software. Queste
@@ -664,7 +664,7 @@ Chiave ``maintenance/contacts``
 '''''''''''''''''''''''''''''''
 
 -  Tipo: Lista di Contatti (vedi sotto)
--  Presenza: obbligatoria (se ``maintenance/type`` **è** ``internal`` oppure ``community``)
+-  Presenza: obbligatoria se ``maintenance/type`` **è** ``internal`` oppure ``community``; opzionale negli altri casi
 
 Uno o più contatti di chi sta mantenendo il software.
 

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -614,7 +614,7 @@ Key ``maintenance/contractors``
 '''''''''''''''''''''''''''''''
 
 -  Type: array of Contractor (see below)
--  Presence: mandatory (if ``maintenance/type`` **is** ``contract``)
+-  Presence: mandatory if ``maintenance/type`` **is** ``contract``; must not be present otherwise
 
 This key describes the entity or entities, if any, that are currently
 contracted for maintaining the software. They can be companies,
@@ -624,7 +624,7 @@ Key ``maintenance/contacts``
 ''''''''''''''''''''''''''''
 
 -  Type: List of Contacts (see below)
--  Presence: mandatory (if ``maintenance/type`` **is** ``internal`` or ``community``)
+-  Presence: mandatory if ``maintenance/type`` **is** ``internal`` or ``community``; optional otherwise
 
 One or more contacts maintaining this software.
 


### PR DESCRIPTION
This clarifies when `maintenance/contractors` and `maintenance/contacts` are expected to be present.

For `contractors`, we now explicitly say it's mandatory if the type is `contract`, and must not be present otherwise. This is _technically_ a breaking change, but it's a sensible and consistent interpretation and we can see it as just removing ambiguity.

For `contacts`, being optional if type is *not* `internal` or `community` was already enforced by publiccode-parser-go, and even the examples in this repo include `contacts` with type `contract`, so it's just stating the de facto behavior.

