### PR TITLE
docs(standard): deprecate it.conforme.* keys

### DIFF
--- a/docs/fr/schema.it.rst
+++ b/docs/fr/schema.it.rst
@@ -24,16 +24,16 @@ Please note how the value of this key is independent from the top-level
 schema versioning is independent both from the core version of the schema and
 from every other Country.
 
-Key ``conforme``
-~~~~~~~~~~~~~~~~
+Key ``conforme`` (*deprecated*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This section contains the keys for auto-declaring the compliance with the
 current legislation, with respect to the following sections.
 Not including these keys implies that the compliance is not known or not
 declared.
 
-Key ``conforme/lineeGuidaDesign``
-'''''''''''''''''''''''''''''''''
+Key ``conforme/lineeGuidaDesign`` (*deprecated*)
+''''''''''''''''''''''''''''''''''''''''''''''''
 
 - Type: boolean
 - Presence: optional
@@ -43,8 +43,8 @@ laws (L. 4/2004), as further explained in the
 `linee guida di
 design <https://docs.italia.it/italia/designers-italia/design-linee-guida-docs>`__ (Italian language).
 
-Key ``conforme/modelloInteroperabilita``
-''''''''''''''''''''''''''''''''''''''''
+Key ``conforme/modelloInteroperabilita`` (*deprecated*)
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 - Type: boolean
 - Presence: optional
@@ -57,8 +57,8 @@ Regulatory reference: `Art. 73 del
 CAD <https://docs.italia.it/italia/piano-triennale-ict/codice-amministrazione-digitale-docs/it/v2017-12-13/_rst/capo8_art73.html>`__ (Italian language).
 
 
-Key ``conforme/misureMinimeSicurezza``
-''''''''''''''''''''''''''''''''''''''
+Key ``conforme/misureMinimeSicurezza`` (*deprecated*)
+'''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 - Type: boolean
 - Presence: optional
@@ -68,8 +68,8 @@ minime di sicurezza ICT per le Pubbliche
 amministrazioni <http://www.agid.gov.it/sites/default/files/documentazione/misure_minime_di_sicurezza_v.1.0.pdf>`__ (Italian language). 
 
 
-Key ``conforme/gdpr``
-'''''''''''''''''''''
+Key ``conforme/gdpr`` (*deprecated*)
+''''''''''''''''''''''''''''''''''''
 
 - Type: boolean
 - Presence: optional

--- a/docs/it/schema.it.rst
+++ b/docs/it/schema.it.rst
@@ -24,16 +24,16 @@ chiave top-level ``publiccodeYmlVersion`` (vedi :ref:`core`). In questo modo,
 il versioning di ogni schema di estensioni è indipendente sia dalla versione
 core dello schema che da ogni altra estensione per Paese.
 
-Sezione ``conforme``
-~~~~~~~~~~~~~~~~~~~~
+Sezione ``conforme`` (*deprecata*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Questa sezione contiene delle chiavi per auto dichiarare la conformità
 con la normativa vigente, rispetto ad alcune sezioni.
 Se queste chiavi non vengono incluse, si intende che la conformità non è nota
 o non viene dichiarata.
 
-Chiave ``conforme/lineeGuidaDesign``
-''''''''''''''''''''''''''''''''''''
+Chiave ``conforme/lineeGuidaDesign`` (*deprecata*)
+''''''''''''''''''''''''''''''''''''''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale
@@ -43,8 +43,10 @@ materia di accessibilità (L. 4/2004), come descritto ulteriormente nelle
 `linee guida di
 design <https://docs.italia.it/italia/designers-italia/design-linee-guida-docs>`__.
 
-Chiave ``conforme/modelloInteroperabilita``
-'''''''''''''''''''''''''''''''''''''''''''
+Non usare questa chiave deprecata, le linee guida sono superate.
+
+Chiave ``conforme/modelloInteroperabilita`` (*deprecata*)
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale
@@ -56,8 +58,10 @@ sull’interoperabilità <https://docs.italia.it/italia/piano-triennale-ict/lg-m
 Riferimento normativo: `Art. 73 del
 CAD <https://docs.italia.it/italia/piano-triennale-ict/codice-amministrazione-digitale-docs/it/v2017-12-13/_rst/capo8_art73.html>`__.
 
-Chiave ``conforme/misureMinimeSicurezza``
-'''''''''''''''''''''''''''''''''''''''''
+Non usare questa chiave deprecata, le linee guida sono superate.
+
+Chiave ``conforme/misureMinimeSicurezza`` (*deprecata*)
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale
@@ -66,8 +70,8 @@ Se presente e impostato a ``yes``, il software è conforme alle `Misure
 minime di sicurezza ICT per le Pubbliche
 amministrazioni <https://www.agid.gov.it/it/sicurezza/misure-minime-sicurezza-ict>`__.
 
-Chiave ``conforme/gdpr``
-''''''''''''''''''''''''
+Chiave ``conforme/gdpr`` (*deprecata*)
+''''''''''''''''''''''''''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale

--- a/docs/standard/schema.it.rst
+++ b/docs/standard/schema.it.rst
@@ -18,16 +18,16 @@ Key ``countryExtensionVersion``
 
 This key **MUST** always be set to ``1.0``.
 
-Key ``conforme``
-~~~~~~~~~~~~~~~~
+Key ``conforme`` (*deprecated*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This section contains the keys for auto-declaring the compliance with the
 current legislation, with respect to the following sections.
 Not including these keys implies that the compliance is not known or not
 declared.
 
-Key ``conforme/lineeGuidaDesign``
-'''''''''''''''''''''''''''''''''
+Key ``conforme/lineeGuidaDesign`` (*deprecated*)
+''''''''''''''''''''''''''''''''''''''''''''''''
 
 - Type: boolean
 - Presence: optional
@@ -37,8 +37,10 @@ laws (L. 4/2004), as further explained in the
 `linee guida di
 design <https://docs.italia.it/italia/designers-italia/design-linee-guida-docs>`__ (Italian language).
 
-Key ``conforme/modelloInteroperabilita``
-''''''''''''''''''''''''''''''''''''''''
+Don't use this deprecated key, those guidelines are no longer current.
+
+Key ``conforme/modelloInteroperabilita`` (*deprecated*)
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 - Type: boolean
 - Presence: optional
@@ -50,9 +52,10 @@ sull’interoperabilità <https://docs.italia.it/italia/piano-triennale-ict/lg-m
 Regulatory reference: `Art. 73 del
 CAD <https://docs.italia.it/italia/piano-triennale-ict/codice-amministrazione-digitale-docs/it/v2017-12-13/_rst/capo8_art73.html>`__ (Italian language).
 
+Don't use this deprecated key, those guidelines are no longer current.
 
-Key ``conforme/misureMinimeSicurezza``
-''''''''''''''''''''''''''''''''''''''
+Key ``conforme/misureMinimeSicurezza`` (*deprecated*)
+'''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 - Type: boolean
 - Presence: optional
@@ -62,8 +65,8 @@ minime di sicurezza ICT per le Pubbliche
 amministrazioni <https://www.agid.gov.it/it/sicurezza/misure-minime-sicurezza-ict>`__ (Italian language).
 
 
-Key ``conforme/gdpr``
-'''''''''''''''''''''
+Key ``conforme/gdpr`` (*deprecated*)
+''''''''''''''''''''''''''''''''''''
 
 - Type: boolean
 - Presence: optional


### PR DESCRIPTION
Deprecate it.conforme.* keys, as they refer to obsolete guidelines and/or are about legal compliance which maintainers are unlikely to take responsibility for.
Because of that, in practice they are rarely used.

