### PR TITLE
docs: don't use GitHub teams links because they are not public

### DIFF
--- a/governance/charter.md
+++ b/governance/charter.md
@@ -11,7 +11,7 @@ tasked with the formal voting required to evolve the core Standard.
 
 All other tools are community-maintained.
 
-## Steering Committee ([@publiccodeyml/steering-committee](https://github.com/orgs/publiccodeyml/teams/steering-committee))
+## Steering Committee (`@publiccodeyml/steering-committee`)
 
 * 🇩🇰 Denmark: [@zorp](https://github.com/zorp) for OS2 Offentlig Digitaliseringsfællesskab
 * 🇫🇷 France: [@bzg](https://github.com/bzg) for the Free Software unit at the Interministerial Digital Directorate

--- a/governance/procedure-proposing-changes-and-voting.md
+++ b/governance/procedure-proposing-changes-and-voting.md
@@ -13,7 +13,7 @@ Request directly on the GitHub repository](https://github.com/publiccodeyml/publ
 The participation in the discussion is encouraged and is free and open to everyone, as is the
 submission of Standard-changing Pull Requests.
 
-The [Maintainers](https://github.com/orgs/publiccodeyml/teams/steering-committee) are responsible
+The [Maintainers](https://github.com/publiccodeyml/publiccode.yml/blob/main/governance/charter.md#maintainer-bfabio-sebbalex) are responsible
 for labelling any change depending on their nature according to the [Semantic
 Versioning](https://semver.org/), or in other words:
 


### PR DESCRIPTION
Fix #224.

