### PR TITLE
docs(standard): use pure ISO 3166-1 alpha-2 instead of an hybrid

### DIFF
--- a/docs/de/country.de.rst
+++ b/docs/de/country.de.rst
@@ -5,7 +5,7 @@ Länderspezifische Extensions
 
 Zwar ist der Standard so strukturiert, dass er international genutzt werden kann, dennoch können Informationen eingefügt werden, die in bestimmten Ländern nützlich sind, z. B. die Angabe, dass bestimmte nationale Gesetze oder Regelungen eingehalten werden.
 
-Alle länderspezifischen Extensions sind in einer Sektion enthalten, die mit dem aus zwei Kleinbuchstaben bestehenden Ländercode gemäß `ISO 3166-1 alpha-2 country code <https://it.wikipedia.org/wiki/ISO_3166-1_alpha-2>`__ bezeichnet ist. Z. B. handelt es sich bei ``spid`` um eine Eigenschaft für italienische Software, die angibt, ob die Software in das italienische öffentliche Identifikationssystem integriert ist.
+Alle länderspezifischen Extensions sind in einer Sektion enthalten, die mit dem aus zwei Kleinbuchstaben (*veraltet*) oder Großbuchstaben bestehenden Ländercode gemäß `ISO 3166-1 alpha-2 country code <https://it.wikipedia.org/wiki/ISO_3166-1_alpha-2>`__ bezeichnet ist. Z. B. handelt es sich bei ``spid`` um eine Eigenschaft für italienische Software, die angibt, ob die Software in das italienische öffentliche Identifikationssystem integriert ist.
 
 Ist dies der Fall, wird dies folgendermaßen angegeben:
 

--- a/docs/de/schema.core.rst
+++ b/docs/de/schema.core.rst
@@ -296,8 +296,8 @@ Key ``intendedAudience/countries``
 
 This key explicitly includes certain countries in the intended audience,
 i.e. the software explicitly claims compliance with specific processes,
-technologies or laws. All countries are specified using lowercase ISO
-3166-1 alpha-2 two-letter country codes.
+technologies or laws. All countries are specified using lowercase (*deprecated*)
+or uppercase ISO 3166-1 alpha-2 two-letter country codes.
 
 Key ``intendedAudience/unsupportedCountries``
 '''''''''''''''''''''''''''''''''''''''''''''
@@ -308,7 +308,7 @@ Key ``intendedAudience/unsupportedCountries``
 This key explicitly marks countries as NOT supported. This might be the
 case if there is a conflict between how software is working and a
 specific law, process or technology. All countries are specified using
-lowercase ISO 3166-1 alpha-2 two-letter country codes.
+lowercase (*deprecated*) or uppercase ISO 3166-1 alpha-2 two-letter country codes.
 
 Key ``intendedAudience/scope``
 ''''''''''''''''''''''''''''''

--- a/docs/fr/country.rst
+++ b/docs/fr/country.rst
@@ -11,7 +11,7 @@ Le mécanisme d'extension fourni est l'utilisation de sections spécifiques
 à chaque pays.
 
 Toutes les extensions spécifiques à un pays sont contenues dans une section
-nommée avec deux lettres minuscules `ISO 3166-1 alpha-2 country
+nommée avec deux lettres minuscules (*deprecated*) ou majuscules `ISO 3166-1 alpha-2 country
 code <https://it.wikipedia.org/wiki/ISO_3166-1_alpha-2>`__. Pour le moment 
 ``spid`` est une propriété pour un logiciel Italien  indiquant  si le logiciel
 est intégré au système italien d'identification publique.

--- a/docs/fr/schema.core.rst
+++ b/docs/fr/schema.core.rst
@@ -308,8 +308,8 @@ Clé ``intendedAudience/countries``
 Cette clé inclut explicitement certains pays dans le public cible,
 par exemple, le logiciel revendique explicitement sa conformité avec
 des processus, des technologies ou des lois spécifiques. 
-Tous les pays sont indiqués à l'aide des deux lettres renvoyant au code du pays, 
-conformément au standard ISO 3166-1 alpha-2.
+Tous les pays sont indiqués à l'aide des deux lettres renvoyant au code du pays,
+en minuscules (*deprecated*) ou en majuscules, conformément au standard ISO 3166-1 alpha-2.
 
 Clé ``intendedAudience/unsupportedCountries``
 '''''''''''''''''''''''''''''''''''''''''''''
@@ -321,8 +321,8 @@ Cette clé mentionne explicitement les pays qui ne sont pas supportés.
 Cette situation peut survenir en cas de conflit entre le mode de
 fonctionnement du logiciel et une loi, un processus ou une technologie
 particulière.
-Tous les pays sont indiqués à l'aide des deux lettres renvoyant au code du pays, 
-conformément au standard ISO 3166-1 alpha-2.
+Tous les pays sont indiqués à l'aide des deux lettres renvoyant au code du pays
+en minuscules (*deprecated*) ou en majuscules, conformément au standard ISO 3166-1 alpha-2.
 
 Clé ``intendedAudience/scope``
 ''''''''''''''''''''''''''''''

--- a/docs/fr/schema.it.rst
+++ b/docs/fr/schema.it.rst
@@ -5,7 +5,8 @@ Italy
 
 All the extensions listed below are specific for Italy and, as such, they must
 be inserted in a section named with the ``it`` code. Every Country is specified
-using a two letters *country code* following the ISO 3166-1 alpha-2 standard.
+using a two letters lowercase (*deprecated*) or uppercase *country code* following
+the ISO 3166-1 alpha-2 standard.
 
 
 Key ``countryExtensionVersion``

--- a/docs/it/country.rst
+++ b/docs/it/country.rst
@@ -12,8 +12,9 @@ prevede l’utilizzo di sezioni specifiche per ogni Paese
 
 Tutte le sezioni specifiche per ogni Paese sono contenute in una sezione
 denominata con l’\ `ISO 3166-1 alpha-2 country
-code <https://it.wikipedia.org/wiki/ISO_3166-1_alpha-2>`__. Ad esempio,
-``spid`` è una proprietà definita per i software italiani per la
+code <https://it.wikipedia.org/wiki/ISO_3166-1_alpha-2>`__ in minuscolo (*deprecato*) o
+in maiuscolo.
+Ad esempio, ``spid`` è una proprietà definita per i software italiani per la
 dichiarazione dell’eventuale compatibilità con il Sistema Pubblico di
 Identità Digitale.
 

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -314,8 +314,8 @@ Chiave ``intendedAudience/countries``
 Questa chiave include in modo esplicito alcuni Paesi tra il pubblico
 previsto, i.e., il software rivendica esplicitamente la conformità con
 processi specifici, tecnologie o leggi. Tutti i Paesi sono specificati
-usando *country code* a due lettere seguendo lo standard ISO 3166-1
-alpha-2.
+usando *country code* a due lettere in minuscolo (*deprecato*) o in maiuscolo,
+seguendo lo standard ISO 3166-1 alpha-2.
 
 Chiave ``intendedAudience/unsupportedCountries``
 ''''''''''''''''''''''''''''''''''''''''''''''''
@@ -327,8 +327,8 @@ Questa chiave contrassegna esplicitamente i Paesi **NON** supportati.
 Questa situazione potrebbe verificarsi nel momento in cui esista un
 conflitto tra la modalità di funzionamento del software ed una legge
 specifica, un processo o una tecnologia. Tutti i Paesi sono specificati
-usando *country code* a due lettere seguendo lo standard ISO 3166-1
-alpha-2.
+usando *country code* a due lettere in minuscolo (*deprecato*) o in maiuscolo,
+seguendo lo standard ISO 3166-1 alpha-2.
 
 Chiave ``intendedAudience/scope``
 '''''''''''''''''''''''''''''''''

--- a/docs/it/schema.it.rst
+++ b/docs/it/schema.it.rst
@@ -6,7 +6,7 @@ Italia
 Tutte le estensioni elencate qui di seguito sono specifiche per l'Italia e, di
 conseguenza, devono essere inserite in una sezione denominata con il codice
 ``it``. Tutti i Paesi sono specificati usando *country code* a due lettere
-seguendo lo standard ISO 3166-1 alpha-2.
+in minuscolo (*deprecato*) o in maiuscolo, seguendo lo standard ISO 3166-1 alpha-2.
 
 
 Chiave ``countryExtensionVersion``

--- a/docs/standard/country.rst
+++ b/docs/standard/country.rst
@@ -10,7 +10,7 @@ laws or regulations. The provided extension mechanism is the usage of
 country-specific sections.
 
 All country-specific sections live under a key named after two-letter
-lowercase `ISO 3166-1 alpha-2 country
+lowercase (*deprecated*) or uppercase `ISO 3166-1 alpha-2 country
 codes <https://it.wikipedia.org/wiki/ISO_3166-1_alpha-2>`__. For instance
 ``spid`` is a property for Italian software declaring whether the
 software is integrated with the Italian Public Identification System.

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -299,8 +299,8 @@ Key ``intendedAudience/countries``
 
 This key explicitly includes certain countries in the intended audience,
 i.e. the software explicitly claims compliance with specific processes,
-technologies or laws. All countries are specified using lowercase ISO
-3166-1 alpha-2 two-letter country codes.
+technologies or laws. All countries are specified using lowercase (*deprecated*)
+or uppercase ISO 3166-1 alpha-2 two-letter country codes.
 
 Key ``intendedAudience/unsupportedCountries``
 '''''''''''''''''''''''''''''''''''''''''''''
@@ -311,7 +311,7 @@ Key ``intendedAudience/unsupportedCountries``
 This key explicitly marks countries as NOT supported. This might be the
 case if there is a conflict between how software is working and a
 specific law, process or technology. All countries are specified using
-lowercase ISO 3166-1 alpha-2 two-letter country codes.
+lowercase (*deprecated*) or uppercase ISO 3166-1 alpha-2 two-letter country codes.
 
 Key ``intendedAudience/scope``
 ''''''''''''''''''''''''''''''

--- a/docs/standard/schema.it.rst
+++ b/docs/standard/schema.it.rst
@@ -5,7 +5,8 @@ Italy
 
 All the keys listed below are specific for Italy and, as such, they must
 be inserted in a section named with the ``it`` code. Every Country is specified
-using a two letters *country code* following the ISO 3166-1 alpha-2 standard.
+using a two letters lowercase (*deprecated*) or uppercase *country code* following
+the ISO 3166-1 alpha-2 standard.
 
 
 Key ``countryExtensionVersion``


### PR DESCRIPTION
Deprecate the usage of lowercase ISO 3166-1 alpha-2 and allow the actual (uppercase) standard to be used.

