### PR TITLE
doc: remove mentions to "core"

### DIFF
--- a/docs/standard/index.rst
+++ b/docs/standard/index.rst
@@ -17,9 +17,8 @@ this enables the Developers Italia crawler to build the `national software
 catalog <https://developers.italia.it/>`__. The standard is also used at
 `opencode.de <https://opencode.de>`__, the German registry of open source for
 public administration. ``publiccode.yml`` is designed to be
-interoperable internationally, thus the country-specific keys are separated by
-the core part and are defined in specific sections that each government can
-rule.
+interoperable internationally, also through country-specific keys defined in
+dedicated sections that each government can regulate.
 
 Details carried by a ``publiccode.yml`` file include: 
 

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -1,7 +1,7 @@
 .. _core:
 
-The Standard (core)
-===================
+The Standard
+============
 
 This document represents the description of the ``publiccode.yml``
 schema.


### PR DESCRIPTION
The "core" part of the standard was an old idea, which is now obsolete as the country specific sections are not a separated thing with their own version anymore.

