### PR TITLE
Switch spelling: "organizations" into "organisations" 

### DIFF
--- a/docs/de/schema.core.rst
+++ b/docs/de/schema.core.rst
@@ -616,7 +616,7 @@ Key ``maintenance/contractors``
 
 This key describes the entity or entities, if any, that are currently
 contracted for maintaining the software. They can be companies,
-organizations, or other collective names.
+organisations, or other collective names.
 
 Key ``maintenance/contacts``
 ''''''''''''''''''''''''''''

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -618,7 +618,7 @@ Key ``maintenance/contractors``
 
 This key describes the entity or entities, if any, that are currently
 contracted for maintaining the software. They can be companies,
-organizations, or other collective names.
+organisations, or other collective names.
 
 Key ``maintenance/contacts``
 ''''''''''''''''''''''''''''


### PR DESCRIPTION
Anticipating https://github.com/publiccodeyml/publiccode.yml/pull/198, I switched the American English spelling of `organizations` into `organisations` :)  