### PR TITLE
doc(standard): make categories optional and add `other`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ name: My text editor
 url: "https://example.com/mysoftware/text-editor.git"
 platforms:
   - windows
-categories:
-  - office
 developmentStatus: development
 softwareType: standalone/desktop
 description:

--- a/docs/de/Example.de.rst
+++ b/docs/de/Example.de.rst
@@ -15,9 +15,6 @@ Minimal-Konfiguration
   platforms:
     - web
 
-  categories:
-    - financial-reporting
-
   developmentStatus: development
 
   softwareType: "standalone/desktop"

--- a/docs/de/categories-list.rst
+++ b/docs/de/categories-list.rst
@@ -1,9 +1,9 @@
 Liste von Software-Kategorien
 =============================
-Es folgt ein festgelegtes Verzeichnis mit nützlichen Tags zur Kategorisierung der Software.
+Es folgt ein festgelegtes Verzeichnis gültiger Kategorien für die Software.
 
-Gültige Tags
-------------
+Gültige Kategorien
+------------------
 
 - accounting
 
@@ -210,3 +210,5 @@ Gültige Tags
 - website-builder
 
 - workflow-management
+
+- other

--- a/docs/de/schema.core.rst
+++ b/docs/de/schema.core.rst
@@ -198,10 +198,10 @@ Key ``categories``
 ~~~~~~~~~~~~~~~~~~
 
 -  Type: array of strings
--  Presence: mandatory
+-  Presence: optional
 -  Acceptable values: see :ref:`categories-list` 
 
-A list of words that can be used to describe the software and can help
+A list of categories that can be used to describe the software and can help
 building catalogs of open software.
 
 The controlled vocabulary :ref:`categories-list` contains the list of allowed

--- a/docs/fr/categories-list.rst
+++ b/docs/fr/categories-list.rst
@@ -3,11 +3,11 @@
 Liste des catégories de logiciel
 ===========================
 
-Ici se trouve une liste contrôlée du vocabulaire des tags utiles pour catégoriser un logiciel.
+Ici se trouve une liste contrôlée du vocabulaire des catégories pour le logiciel.
 
-==========
-Tags valides
-==========
+==================
+Catégories valides
+==================
 
 - accounting
 - agile-project-management
@@ -113,3 +113,4 @@ Tags valides
 - website-builder
 - whistleblowing
 - workflow-management
+- other

--- a/docs/fr/example/publiccode.minimal.yml
+++ b/docs/fr/example/publiccode.minimal.yml
@@ -5,9 +5,6 @@ url: "https://example.com/italia/medusa.git"
 platforms:
   - web
 
-categories:
-  - financial-reporting
-
 developmentStatus: development
 
 softwareType: "standalone/desktop"
@@ -15,17 +12,17 @@ softwareType: "standalone/desktop"
 description:
   en:
     shortDescription: >
-          A rather short description which
-          is probably useless
+      A rather short description which
+      is probably useless
 
     longDescription: >
-          Very long description of this software, also split
-          on multiple rows. You should note what the software
-          is and why one should need it. We can potentially
-          have many pages of text here.
+      Very long description of this software, also split
+      on multiple rows. You should note what the software
+      is and why one should need it. We can potentially
+      have many pages of text here.
 
     features:
-       - Just one feature
+      - Just one feature
 
 legal:
   license: AGPL-3.0-or-later

--- a/docs/fr/schema.core.rst
+++ b/docs/fr/schema.core.rst
@@ -205,10 +205,10 @@ Clé ``categories``
 ~~~~~~~~~~~~~~~~~~
 
 -  Type: array de chaînes de caractères
--  Présence: obligatoire
+-  Présence: facultative
 -  Valeurs acceptées: voir :ref:`categories-list` 
 
-Une liste des mots qui peuvent être utilisés pour décrire le logiciel
+Une liste des categories qui peuvent être utilisés pour décrire le logiciel
 et aider à la constitution d'un catalogue des logiciels ouverts.
 
 Le vocabulaire contrôlé de la :ref:`categories-list` présente la liste

--- a/docs/it/categories-list.rst
+++ b/docs/it/categories-list.rst
@@ -3,12 +3,11 @@
 Lista delle categorie di software
 =================================
 
-Qui di seguito è presentato un vocabolario controllato di tag utilizzabili
-per categorizzare il software.
+Qui di seguito è presentato un vocabolario controllato delle categorie utilizzabili.
 
-==========
-Tag Validi
-==========
+================
+Categorie valide
+================
 - accounting
 - agile-project-management
 - applicant-tracking
@@ -114,3 +113,4 @@ Tag Validi
 - website-builder
 - whistleblowing
 - workflow-management
+- other

--- a/docs/it/example/publiccode.minimal.yml
+++ b/docs/it/example/publiccode.minimal.yml
@@ -5,9 +5,6 @@ url: "https://example.com/italia/medusa.git"
 platforms:
   - web
 
-categories:
-  - financial-reporting
-
 developmentStatus: development
 
 softwareType: "standalone/desktop"
@@ -15,17 +12,17 @@ softwareType: "standalone/desktop"
 description:
   en:
     shortDescription: >
-          A rather short description which
-          is probably useless
+      A rather short description which
+      is probably useless
 
     longDescription: >
-          Very long description of this software, also split
-          on multiple rows. You should note what the software
-          is and why one should need it. We can potentially
-          have many pages of text here.
+      Very long description of this software, also split
+      on multiple rows. You should note what the software
+      is and why one should need it. We can potentially
+      have many pages of text here.
 
     features:
-       - Just one feature
+      - Just one feature
 
 legal:
   license: AGPL-3.0-or-later

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -212,10 +212,10 @@ Chiave ``categories``
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Tipo: array di stringhe
--  Presenza: obbligatoria
+-  Presenza: opzionale
 -  Valori accettabili: vedi :ref:`categories-list` 
 
-Una lista di parole che possono essere usate per descrivere il software
+Una lista di categorie che possono essere usate per descrivere il software
 e possono aiutare a costruire il catalogo di software open.
 
 Il vocabolario controllato :ref:`categories-list` presenta la lista dei valori

--- a/docs/standard/categories-list.rst
+++ b/docs/standard/categories-list.rst
@@ -3,12 +3,11 @@
 List of software categories
 ===========================
 
-Here follows a controlled vocabulary of useful tags for categorizing the
-software.
+Here follows a controlled vocabulary of allowed categories for the software.
 
-==========
-Valid Tags
-==========
+================
+Valid categories
+================
 
 - accounting
 - agile-project-management
@@ -115,3 +114,4 @@ Valid Tags
 - website-builder
 - whistleblowing
 - workflow-management
+- other

--- a/docs/standard/example/publiccode.minimal.yml
+++ b/docs/standard/example/publiccode.minimal.yml
@@ -5,9 +5,6 @@ url: "https://example.com/italia/medusa.git"
 platforms:
   - web
 
-categories:
-  - financial-reporting
-
 developmentStatus: development
 
 softwareType: "standalone/desktop"
@@ -15,17 +12,17 @@ softwareType: "standalone/desktop"
 description:
   en:
     shortDescription: >
-          A rather short description which
-          is probably useless
+      A rather short description which
+      is probably useless
 
     longDescription: >
-          Very long description of this software, also split
-          on multiple rows. You should note what the software
-          is and why one should need it. We can potentially
-          have many pages of text here.
+      Very long description of this software, also split
+      on multiple rows. You should note what the software
+      is and why one should need it. We can potentially
+      have many pages of text here.
 
     features:
-       - Just one feature
+      - Just one feature
 
 legal:
   license: AGPL-3.0-or-later

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -201,10 +201,10 @@ Key ``categories``
 ~~~~~~~~~~~~~~~~~~
 
 -  Type: array of strings
--  Presence: mandatory
+-  Presence: optional
 -  Acceptable values: see :ref:`categories-list` 
 
-A list of words that can be used to describe the software and can help
+A list of categories that can be used to describe the software and can help
 building catalogs of open software.
 
 The controlled vocabulary :ref:`categories-list` contains the list of allowed


### PR DESCRIPTION
The list of categories have always being a problem, stuck between:

* keeping the list short and curated, which excludes legit use cases and annoys authors
* making it huge and comprehensive, which turns it into a mess nobody can navigate
* maintaining it manually, which is slow, political, and opaque
* avoiding local categorizations (probably a good call), but ending up with a list that feels incomplete

Make them optional, so if people feel they fit in their usecase they can opt in, otherwise they can ignore them or user `other`.

Fix #217.

