### PR TITLE
Bump python version

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -3,7 +3,7 @@ on:
     types: [created]
 jobs:
   bot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: publiccodeyml/bot@main
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - run: pip install -r requirements.txt
       - run: sphinx-build docs/standard build -c .

--- a/README.md
+++ b/README.md
@@ -106,17 +106,20 @@ searching using the frontend or the API.
 
 **Latest release:** [![GitHub release](https://img.shields.io/github/release/publiccodeyml/publiccode.yml.svg?style=plastic)](https://github.com/publiccodeyml/publiccode.yml/releases) [See all versions](https://github.com/publiccodeyml/publiccode.yml/releases)
 
-This project follows the Semantic Versioning.  For more information see
-[SemVer.org](https://semver.org/).
+This project follows the [Semantic Versioning](https://semver.org/).
 
 ## Contributing
 
-Feel free to submit [Pull Requests and to file Issues](CONTRIBUTING.md).
+Feel free to submit [Pull Requests, file Issues](CONTRIBUTING.md) or open
+a [Discussion](https://github.com/publiccodeyml/publiccode.yml/discussions). 
 
-The Standard's website (https://yml.publiccode.tools) is built using the Python Sphinx package.
+The [Standard's website](https://yml.publiccode.tools) is built using the Python
+Sphinx package and
+[deployed](https://github.com/publiccodeyml/publiccode.yml/blob/main/.github/workflows/publish.yml)
+on GitHub Pages.
 
 ### Prerequisites
-- Python 3.9
+- Python 3.11
 
 ### Install dependencies
 
@@ -125,12 +128,16 @@ pip install -r requirements.txt
 ```
 
 ### Local development process
-`spinx-build` can be used to compile all source file to static html files. Run this command to generate the website:
+`spinx-build` can be used to compile all source file to static html files. Run
+this command to generate the website:
 
 ```console
 sphinx-build docs/standard build -c .
 ```
 
-## Licence
+then open the relevant file in the build directory with a browser (e.g.,
+`build/index.html`) to explore the contents.
 
-Licenced under the [CC0-1.0](LICENSE).
+## License
+
+Licensed under the [CC0-1.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ pip install -r requirements.txt
 ```
 
 ### Local development process
-`spinx-build` can be used to compile all source file to static html files. Run
+`sphinx-build` can be used to compile all source file to static html files. Run
 this command to generate the website:
 
 ```console

--- a/docs/standard/example.rst
+++ b/docs/standard/example.rst
@@ -14,7 +14,7 @@ Minimum Version
 
 
 Extended Version
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. literalinclude:: example/publiccode.yml
    :language: yaml


### PR DESCRIPTION
This PR:
* bumps Python from 3.9 to 3.11. Since 3.11 `imghdr` is deprecated and it is removed starting 3.13 (so the build with the current requirements fails with 3.13). To solve this I think It's probably better to move to a later version of Sphinx if/when necessary.
* pins ubuntu to the latest available LTS (24.04) in the workflows
* fixes a Sphinx warning
* adds some small info in the README file

Oh, I like to say licen`s`ed way more than licen`c`ed, in the same way that I like licenSe more than licenCe but I guess that's just personal taste?

Fixes #243 