### PR TITLE
Add sphinx-copybutton extension

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -21,4 +21,5 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.doctest",
+    "sphinx_copybutton",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,6 @@ version = "0.5.0"
 requires-python = "==3.14.0"
 dependencies = [
     "sphinx==8.2.3",
+    "sphinx-copybutton>=0.5.2",
     "sphinx-press-theme==0.9.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -147,12 +147,14 @@ version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "sphinx" },
+    { name = "sphinx-copybutton" },
     { name = "sphinx-press-theme" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "sphinx", specifier = "==8.2.3" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-press-theme", specifier = "==0.9.1" },
 ]
 
@@ -224,6 +226,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3", size = 3589741, upload-time = "2025-03-02T22:31:56.836Z" },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
As discussed in #266, this PR adds the https://github.com/executablebooks/sphinx-copybutton extension.