### PR TITLE
[README.md] Use proper search term and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ localisation:
 ## Finding projects
 
 Finding projects depends on how the search API is structured for every hosting
-platform. For example, you can find all `publiccode.yml` on GitHub files by
-searching using the frontend or the API.
+platform. For example, you can find all `publiccode.yml` files in the root
+directory of projects on GitHub, either by using the search frontend or the API.
 
-* [GitHub Search `path:publiccode.yml`](https://github.com/search?q=path%3Apubliccode.yml&type=code)
+* [GitHub Search `path:/^publiccode.yml$/`](https://github.com/search?q=path%3A%2F%5Epubliccode.yml%24%2F&type=code)
 
 ## Versioning
 


### PR DESCRIPTION
Narrow down the search significantly, in order to solely find files named `publiccode.yml` in the root directory of projects on GitHub.  Also describe that concisely.  Based on https://github.com/italia/publiccode.yml-docs/pull/1
Note, before all files which contained the string `publiccode.yml` somewhere in their file-path were emitted.

