### PR TITLE
Add documentation example for dual license projects

### DIFF
--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -582,11 +582,11 @@ Key ``legal/license``
 
 -  Type: string
 -  Presence: mandatory
--  Example: ``"AGPL-3.0-or-later"``
+-  Example: ``"AGPL-3.0-or-later"``, ``"EUPL-1.2 OR AGPL-3.0-or-later"``
 
 This string describes the license under which the software is
 distributed. The string must contain a valid SPDX expression, referring
-to one (or multiple) open-source license. Please refer to the `SPDX
+to one or multiple open-source licenses. Please refer to the `SPDX
 documentation <https://spdx.org/licenses/>`__ for further information.
 
 Key ``legal/mainCopyrightOwner``


### PR DESCRIPTION
Hello!

I develop public transit related software for Digitransit in Finland. We were asked to add a `publiccode.yml` file to our repository: https://github.com/HSLdevcom/digitransit-ui/issues/5620. This PR adds an example for dual-license projects to make the documentation more clear.