### PR TITLE
 docs: remove cknebel from the Steering Commitee

### DIFF
--- a/governance/charter.md
+++ b/governance/charter.md
@@ -15,7 +15,6 @@ All other tools are community-maintained.
 
 * 🇩🇰 Denmark: [@zorp](https://github.com/zorp) for OS2 Offentlig Digitaliseringsfællesskab
 * 🇫🇷 France: [@bzg](https://github.com/bzg) for the Free Software unit at the Interministerial Digital Directorate
-* 🇩🇪 Germany: [@cknebel](https://github.com/cknebel) (publicplan GmbH)
 * 🇮🇱 Israel: [@ShimonShore](https://github.com/ShimonShore) (Israel Ministry of Science and
   Technology)
 * 🇮🇹 Italy: [@dptdgi](https://github.com/dptdgi) for DTD (Presidenza del Consiglio dei Ministri)
@@ -50,3 +49,4 @@ level.
 
 Active members from the community may be invited as non-voting members with the approval of at
 least the majority of the Steering Committee.
+


### PR DESCRIPTION
Remove @cknebel from the Steering Committee, since there hasn't been any participation for a long time.

@cknebel if this is not correct and you're still active, please feel free to vote against this change or comment here so we can revert it.