### PR TITLE
docs(standard): logo size and format clarification

### DIFF
--- a/docs/de/schema.core.rst
+++ b/docs/de/schema.core.rst
@@ -121,8 +121,7 @@ Key ``logo``
 -  Example: ``"img/logo.svg"``
 
 This key contains the path to the logo of the software. Logos should be
-in vector format; raster formats are only allowed as a fallback. In this
-case, they should be transparent PNGs, minimum 1000px of width.
+in vector format.
 The key value can be the relative path to the file starting from the root of
 the repository, or it can be an absolute URL pointing to the logo in raw
 version. In both cases, the file must reside inside the same repository where

--- a/docs/fr/schema.core.rst
+++ b/docs/fr/schema.core.rst
@@ -123,9 +123,7 @@ Clé ``logo``
 -  Exemple: ``"img/logo.svg"``
 
 Cette clé contient le chemin du logo du logiciel. Les logos doivent être
-dans un format de fichier vectoriel ; les format raster sont uniquement
-acceptés en dernier recours. Dans ce cas, il s'agit de fichiers PNG
-transparents, d’une largeur minimale de 1000px. 
+dans un format de fichier vectoriel. 
 La valeur de la clé peut être le chemin relatif du fichier à partir de la
 racine du dépôt ou une URL absolue qui pointe vers la version brute du logo.
 Dans les deux cas, le fichier doit être situé dans le même dépôt que le

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -135,9 +135,7 @@ Questa chiave indica il logo del software. Il valore può essere il percorso
 relativo al file a partire dalla root del repository, oppure una URL assoluta
 che punta al logo in versione raw. In entrambi i casi, il file deve risiedere
 all'interno del medesimo repository che contiene il ``publiccode.yml``.  Il logo
-dovrebbe essere in formato vettoriale; i formati raster sono solo accettabili
-come fallback. In questo caso, dovrebbero essere PNG trasparenti, con una
-larghezza minima di 1000px.
+dovrebbe essere in formato vettoriale.
 
 Chiave ``monochromeLogo``
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -123,9 +123,8 @@ Key ``logo``
 -  Acceptable formats: SVG, SVGZ, PNG
 -  Example: ``"img/logo.svg"``
 
-This key contains the path to the logo of the software. Logos should be
-in vector format; raster formats are only allowed as a fallback. In this
-case, they should be transparent PNGs, minimum 1000px of width.
+This key contains the path to the logo of the software. Logos SHOULD be
+in vector format.
 The key value can be the relative path to the file starting from the root of
 the repository, or it can be an absolute URL pointing to the logo in raw
 version. In both cases, the file must reside inside the same repository where


### PR DESCRIPTION
Make the logo requirements clear.

Fix #34.

