### PR TITLE
docs(schema): fix leftover Italian "Chiave" in English schema header

### DIFF
--- a/docs/standard/schema.it.rst
+++ b/docs/standard/schema.it.rst
@@ -127,8 +127,8 @@ Section ``riuso``
 This section contains a set of keys related to the publication of the software
 inside the reuse catalog of `Developers Italia <https://developers.italia.it>`__.
 
-Chiave ``riuso/codiceIPA`` (*deprecated*)
-'''''''''''''''''''''''''''''''''''''''''
+Key ``riuso/codiceIPA`` (*deprecated*)
+''''''''''''''''''''''''''''''''''''''
 
 -  Type: string (iPA code) 
 -  Presence: mandatory if ``repoOwner`` is a Public Administration 


### PR DESCRIPTION
Fixes #313. The English schema reference page at https://yml.publiccode.tools/country.html (sourced from `docs/standard/schema.it.rst`) had one section header that was still in Italian — `Chiave ``riuso/codiceIPA`` (*deprecated*)` — while every other sibling header in the same file uses `Key`. This was the only leftover Italian on line 130.

## Changes

- `docs/standard/schema.it.rst`: `Chiave` → `Key` on line 130.
- Adjusted the RST underline by 6 characters so it matches the new heading length (RST requires the underline to be >= the title length).

## Verification

Before:
```
$ grep -cE '^Key |^Chiave ' docs/standard/schema.it.rst
12
$ grep -n '^Chiave ' docs/standard/schema.it.rst
130:Chiave ``riuso/codiceIPA`` (*deprecated*)
```

After:
```
$ grep -cE '^Key |^Chiave ' docs/standard/schema.it.rst
12
$ grep -n '^Chiave ' docs/standard/schema.it.rst
(no results)
```

All 12 `Key ...` section headers now follow the same pattern. Page renders to `country.html` at build time, so the fix lands on the published page automatically.

## Non-goals

- Only the `Chiave` → `Key` case the issue called out. Not touching any of the field names in backticks (like `piattafome` on line 107, which is inside a key identifier and therefore intentional / out of scope for a language-consistency fix).
- No changes to `docs/standard/schema.core.rst` or `docs/standard/country.rst`.

Fixes #313
