### PR TITLE
docs(spec): remove deprecated Italian keys

### DIFF
--- a/docs/standard/schema.it.rst
+++ b/docs/standard/schema.it.rst
@@ -17,62 +17,6 @@ Key ``countryExtensionVersion``
 
 This key **MUST** always be set to ``1.0``.
 
-Key ``conforme`` (*deprecated*)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This section contains the keys for auto-declaring the compliance with the
-current legislation, with respect to the following sections.
-Not including these keys implies that the compliance is not known or not
-declared.
-
-Key ``conforme/lineeGuidaDesign`` (*deprecated*)
-''''''''''''''''''''''''''''''''''''''''''''''''
-
-- Type: boolean
-- Presence: optional
-
-If present and set to ``true``, the software is compliant with the Italian accessibility
-laws (L. 4/2004), as further explained in the 
-`linee guida di
-design <https://docs.italia.it/italia/designers-italia/design-linee-guida-docs>`__ (Italian language).
-
-Don't use this deprecated key, those guidelines are no longer current.
-
-Key ``conforme/modelloInteroperabilita`` (*deprecated*)
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-- Type: boolean
-- Presence: optional
-
-If present and set to ``true``, the software is compliant with the `linee
-guida
-sull’interoperabilità <https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs>`__.
-
-Regulatory reference: `Art. 73 del
-CAD <https://docs.italia.it/italia/piano-triennale-ict/codice-amministrazione-digitale-docs/it/v2017-12-13/_rst/capo8_art73.html>`__ (Italian language).
-
-Don't use this deprecated key, those guidelines are no longer current.
-
-Key ``conforme/misureMinimeSicurezza`` (*deprecated*)
-'''''''''''''''''''''''''''''''''''''''''''''''''''''
-
-- Type: boolean
-- Presence: optional
-
-If present and set to ``true``, the software is compliant with the `Misure
-minime di sicurezza ICT per le Pubbliche
-amministrazioni <https://www.agid.gov.it/it/sicurezza/misure-minime-sicurezza-ict>`__ (Italian language).
-
-
-Key ``conforme/gdpr`` (*deprecated*)
-''''''''''''''''''''''''''''''''''''
-
-- Type: boolean
-- Presence: optional
-
-If present and set to ``true``, the software respects the GDPR.
-
-
 Section ``piattaforme``
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -119,22 +63,3 @@ Key ``piattaforme/io``
 - Presence: optional
 
 If present and set to ``true``, the software interfaces with `IO - the public services app <https://io.italia.it/>`__.
-
-
-Section ``riuso``
-~~~~~~~~~~~~~~~~~
-
-This section contains a set of keys related to the publication of the software
-inside the reuse catalog of `Developers Italia <https://developers.italia.it>`__.
-
-Key ``riuso/codiceIPA`` (*deprecated*)
-''''''''''''''''''''''''''''''''''''''
-
--  Type: string (iPA code) 
--  Presence: mandatory if ``repoOwner`` is a Public Administration 
--  Example: ``c_h501``
-
-This key represents the administration code inside the Public Administration
-index (codice IPA).
-
-This key is deprecated, use ``organisation/uri`` instead.


### PR DESCRIPTION
Drop the deprecated IT keys ahead of the 1.0 release: the conforme section and riuso/codiceIPA. codiceIPA was the only key under riuso, so that section goes too. The reuse catalog now uses organisation/uri.

See #304.

