### PR TITLE
ci: save a vote log within the comment

### DIFF
--- a/.github/workflows/vote-log-sync.yml
+++ b/.github/workflows/vote-log-sync.yml
@@ -1,0 +1,14 @@
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+jobs:
+  vote-log-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: publiccodeyml/bot@main
+        with:
+          username: yaml-9000
+        env:
+          GITHUB_TOKEN: ${{ secrets.YAML_BOT_TOKEN }}


### PR DESCRIPTION
Save a vote log within the vote-start comment in order to have a persistent trace of the people who voted.

