### PR TITLE
ci: build the website from every version line

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,14 +3,27 @@ name: publish
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
+      - "v[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+-rc"
     tags:
       - "*"
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # The toolchain (poly.py, conf.py, templates) always comes from main,
+      # the content of each version from its branch.
       - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
       - uses: actions/setup-python@v7
         with:
           python-version-file: "pyproject.toml"
@@ -20,11 +33,19 @@ jobs:
           version: "0.9.7"
           enable-cache: true
 
-      - run: uv run sphinx-build docs/standard build -c .
-      - run: echo yml.publiccode.tools > build/CNAME
+      # sphinx-polyversion only looks at local branches
+      - name: Create the version branches
+        run: |
+          for ref in $(git for-each-ref --format='%(refname:lstrip=3)' 'refs/remotes/origin/v[0-9]*' 'refs/remotes/origin/[0-9]*-rc'); do
+            git branch "$ref" "origin/$ref"
+          done
+          git branch --list
+
+      - run: uv run sphinx-polyversion poly.py build/html -vv
+      - run: echo yml.publiccode.tools > build/html/CNAME
 
       - name: Publish on GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          publish_dir: ./build/html

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ Thumbs.db
 # Swap files
 *.swp
 
+# Python
+__pycache__/
+
 # Sphinx
 build

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ on GitHub Pages.
 
 ### Local development process
 
-`sphinx-build` can be used to compile all source file to static html files. Run
-this command to generate the website:
+`sphinx-build` can be used to compile all source files of the current
+checkout to static html files. Run this command to generate the website:
 
 ```console
 uv run sphinx-build docs/standard build -c .
@@ -124,7 +124,27 @@ then open the relevant file in the build directory with a browser (e.g.,
 `sphinx-autobuild` can be used to make use of hot reloading.
 
 ```console
-sphinx-autobuild docs build
+uv run sphinx-autobuild docs/standard build -c .
+```
+
+#### All the versions
+
+The published website puts every version line of the Standard side by
+side, one directory per major version (`/v0/`, `/v1/`, ...) with a
+version switcher on each page. Each line is built from its branch
+(`v0.7`, `1.0-rc`, ...) using the `conf.py` and templates of the current
+checkout, see `poly.py`. The branches must exist locally (e.g.
+`git branch v0.7 origin/v0.7`), then:
+
+```console
+uv run sphinx-polyversion poly.py build/html
+```
+
+To preview the switcher on the current checkout alone, without building
+every branch:
+
+```console
+uv run sphinx-polyversion poly.py build/html -l
 ```
 
 ## Tooling

--- a/_templates/page.html
+++ b/_templates/page.html
@@ -1,0 +1,88 @@
+{%- extends "!page.html" %}
+
+{#- `versions`, `current` and `latest` come from poly.py through
+    html_context. A plain sphinx-build leaves them undefined and this
+    template adds nothing. The style and the script live in the <head>
+    because the theme's Vue app re-renders the whole body. -#}
+
+{% block extrahead %}
+{{ super() }}
+{% if versions is defined and versions %}
+<style>
+  .version-switcher {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 16px;
+    margin: 0 0 16px 0;
+    background: rgba(0, 0, 0, 0.04);
+    border-radius: 6px;
+    font-size: 0.9em;
+  }
+  .version-switcher label {
+    font-weight: 600;
+    white-space: nowrap;
+    margin: 0;
+  }
+  .version-switcher select {
+    padding: 4px 8px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 4px;
+    font-size: 0.95em;
+    background: inherit;
+    color: inherit;
+  }
+  .version-banner {
+    margin: 0 0 16px 0 !important;
+  }
+</style>
+<script>
+  // Same page in the chosen version when it exists there, its index otherwise.
+  function switchVersion(select) {
+    var index = select.value;
+    var page = index + select.dataset.page;
+    fetch(page, { method: "HEAD" })
+      .then(function (response) {
+        window.location.href = response.ok ? page + window.location.hash : index;
+      })
+      .catch(function () {
+        window.location.href = index;
+      });
+  }
+</script>
+{% endif %}
+{% endblock %}
+
+{% block body_header %}
+{% if versions is defined and versions %}
+{#- Pages live one level below the site root, inside their version directory -#}
+{% set prefix = '../' * (pagename.count('/') + 1) %}
+<div class="version-switcher">
+  <label for="version-select">Version:</label>
+  <select id="version-select" data-page="{{ pagename }}.html" onchange="switchVersion(this)">
+    {% for v in versions %}
+    <option value="{{ prefix }}{{ v.dir }}/"{% if v.dir == current.dir %} selected{% endif %}>
+      {{- v.name }}{% if v.prerelease %} (pre-release){% elif v.latest %} (latest){% endif -%}
+    </option>
+    {% endfor %}
+  </select>
+</div>
+
+{% if current.prerelease %}
+<div class="admonition note version-banner">
+  <p class="admonition-title">Pre-release</p>
+  <p>You are viewing <strong>{{ current.name }}</strong>, a draft of the next
+  version of the Standard that can still change.
+  {%- if latest %} The latest released version is
+  <a href="{{ prefix }}{{ latest.dir }}/">{{ latest.name }}</a>.{% endif %}</p>
+</div>
+{% elif latest and current.dir != latest.dir %}
+<div class="admonition warning version-banner">
+  <p class="admonition-title">Outdated version</p>
+  <p>You are viewing <strong>{{ current.name }}</strong>. The latest version is
+  <a href="{{ prefix }}{{ latest.dir }}/">{{ latest.name }}</a>.</p>
+</div>
+{% endif %}
+{% endif %}
+{{ super() }}
+{% endblock %}

--- a/conf.py
+++ b/conf.py
@@ -13,6 +13,21 @@
 
 project = "publiccode.yml Standard (v0.7)"
 
+# Under sphinx-polyversion (poly.py) POLYVERSION_DATA carries the version
+# being built and the list of all of them; load() copies it into
+# html_context for the switcher in _templates/page.html. A plain
+# sphinx-build leaves the variable unset and the switcher renders nothing.
+from sphinx_polyversion.api import LoadError, load
+
+try:
+    load(globals())
+except LoadError:
+    pass
+else:
+    # The switcher names the version on every page, and the bare name is
+    # what still fits the navbar on a phone.
+    project = "publiccode.yml Standard"
+
 html_theme = "press"
 
 templates_path = ["_templates"]

--- a/poly.py
+++ b/poly.py
@@ -1,0 +1,168 @@
+"""sphinx-polyversion config: one website out of every version line.
+
+Run with ``uv run sphinx-polyversion poly.py build/html`` (add ``-l`` to
+preview the current checkout only, with a mocked version list).
+"""
+
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from sphinx_polyversion import DefaultDriver, apply_overrides
+from sphinx_polyversion.environment import Environment
+from sphinx_polyversion.git import Git, GitRef, GitRefType, file_predicate
+from sphinx_polyversion.sphinx import SphinxBuilder
+
+#: Version lines live on mutable branches: ``vMAJOR.MINOR`` once released,
+#: ``MAJOR.MINOR-rc`` while the next release is being drafted. No tags.
+BRANCH_REGEX = r"^v?(?P<major>\d+)\.(?P<minor>\d+)(?P<rc>-rc)?$"
+TAG_REGEX = r"^$"
+
+#: One subdirectory per major line (``v0/``, ``v1/``) holding its newest
+#: branch, so links stay stable across minor releases, plus redirects at
+#: the root for the unversioned URLs published before this layout.
+OUTPUT_DIR = "build/html"
+
+#: Doc source inside each revision. conf.py stays at the repo root and is
+#: shared by every version: sphinx runs against this checkout's conf.py
+#: and templates while the .rst files come from the revision being built.
+SOURCE_DIR = "docs/standard"
+
+#: Extra arguments for sphinx-build.
+SPHINX_ARGS = ""
+
+#: Used only for local builds (``-l``): renders the switcher without git.
+MOCK_DATA = {
+    "revisions": [
+        GitRef("1.0-rc", "", "", GitRefType.BRANCH, datetime.fromtimestamp(2)),
+        GitRef("v0.7", "", "", GitRefType.BRANCH, datetime.fromtimestamp(1)),
+    ],
+    "current": GitRef("v0.7", "", "", GitRefType.BRANCH, datetime.fromtimestamp(1)),
+}
+
+MOCK = False
+SEQUENTIAL = False
+
+apply_overrides(globals())
+
+root = Git.root(Path(__file__).parent)
+src = Path(SOURCE_DIR)
+version_pattern = re.compile(BRANCH_REGEX)
+
+REDIRECT = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>publiccode.yml Standard</title>
+<link rel="canonical" href="{target}">
+<meta http-equiv="refresh" content="0; url={target}">
+<script>location.replace("{target}" + location.hash);</script>
+</head>
+<body>
+<p>Moved to <a href="{target}">{target}</a>.</p>
+</body>
+</html>
+"""
+
+
+def parse(name):
+    match = version_pattern.fullmatch(name)
+    return int(match["major"]), int(match["minor"]), match["rc"] is None
+
+
+def rank(rev):
+    """Newest major first, then a release before its candidate, then newest minor."""
+    major, minor, stable = parse(rev.name)
+    return major, stable, minor
+
+
+def line(rev):
+    return f"v{parse(rev.name)[0]}"
+
+
+class Lines(Git):
+    """Build one branch per major line: the newest release, or the candidate if none."""
+
+    async def retrieve(self, root):
+        best = {}
+        for ref in await super().retrieve(root):
+            key = line(ref)
+            if key not in best or rank(ref) > rank(best[key]):
+                best[key] = ref
+        return tuple(best.values())
+
+
+def catalog(revisions):
+    """Plain dicts for the templates, newest line first."""
+    versions = [
+        {"name": rev.name, "dir": line(rev), "prerelease": not parse(rev.name)[2]}
+        for rev in sorted(revisions, key=rank, reverse=True)
+    ]
+    stable = [v for v in versions if not v["prerelease"]]
+    latest = stable[0] if stable else None
+    for v in versions:
+        v["latest"] = v is latest
+    return {"versions": versions, "latest": latest, "default": latest or versions[0]}
+
+
+def page_data(driver, rev, env):
+    data = catalog(driver.targets)
+    data["current"] = next(v for v in data["versions"] if v["name"] == rev.name)
+    return data
+
+
+def root_data(driver):
+    return catalog(driver.targets)
+
+
+def write_redirects(out, default):
+    """Keep the unversioned URLs alive: the root and every page of the default
+    version redirect into its directory, fragment included."""
+    for page in (out / default).rglob("*.html"):
+        rel = page.relative_to(out / default)
+        target = "../" * (len(rel.parts) - 1) + f"{default}/{rel.as_posix()}"
+        if rel.as_posix() == "index.html":
+            target = f"{default}/"
+        stub = out / rel
+        stub.parent.mkdir(parents=True, exist_ok=True)
+        stub.write_text(REDIRECT.format(target=target))
+
+
+class Driver(DefaultDriver):
+    def build_failed(self, rev, exc_info):
+        super().build_failed(rev, exc_info)
+        # A broken version must fail the run, not publish a partial website.
+        raise exc_info[1]
+
+    async def build_root(self):
+        if not self.targets:
+            sys.exit(
+                "no version branches found: poly.py builds the local branches "
+                "matching BRANCH_REGEX, create them first "
+                "(e.g. git branch v0.7 origin/v0.7)"
+            )
+        await super().build_root()
+        default = "local" if MOCK else catalog(self.targets)["default"]["dir"]
+        write_redirects(self.output_dir, default)
+
+
+# All version lines share the same doc toolchain, so reuse the active
+# environment instead of provisioning one per build.
+Driver(
+    root,
+    OUTPUT_DIR,
+    vcs=Lines(
+        branch_regex=BRANCH_REGEX,
+        tag_regex=TAG_REGEX,
+        predicate=file_predicate([src]),
+    ),
+    builder=SphinxBuilder(src, args=["-c", str(root), *SPHINX_ARGS.split()]),
+    env=Environment.factory(),
+    namer=line,
+    data_factory=page_data,
+    root_data_factory=root_data,
+    template_dir=root / "templates",
+    mock=MOCK_DATA,
+).run(MOCK, SEQUENTIAL)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,6 @@ dependencies = [
     "sphinx==8.2.3",
     "sphinx-autobuild>=2025.8.25",
     "sphinx-copybutton>=0.5.2",
+    "sphinx-polyversion>=2.0.0",
     "sphinx-press-theme==0.9.1",
 ]

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Page not found - publiccode.yml Standard</title>
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    max-width: 40em;
+    margin: 4em auto;
+    padding: 0 1em;
+    line-height: 1.5;
+    color: #2c3e50;
+  }
+  a { color: #3eaf7c; }
+</style>
+</head>
+<body>
+<h1>Page not found</h1>
+<p>This page does not exist in the version of the publiccode.yml Standard you
+asked for. It may belong to another version:</p>
+<ul>
+{% for v in versions %}
+<li><a href="/{{ v.dir }}/">{{ v.name }}</a>{% if v.prerelease %} (pre-release){% elif v.latest %} (latest){% endif %}</li>
+{% endfor %}
+</ul>
+</body>
+</html>

--- a/uv.lock
+++ b/uv.lock
@@ -182,6 +182,7 @@ dependencies = [
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-copybutton" },
+    { name = "sphinx-polyversion" },
     { name = "sphinx-press-theme" },
 ]
 
@@ -190,6 +191,7 @@ requires-dist = [
     { name = "sphinx", specifier = "==8.2.3" },
     { name = "sphinx-autobuild", specifier = ">=2025.8.25" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
+    { name = "sphinx-polyversion", specifier = ">=2.0.0" },
     { name = "sphinx-press-theme", specifier = "==0.9.1" },
 ]
 
@@ -290,6 +292,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
+]
+
+[[package]]
+name = "sphinx-polyversion"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/01/7755fc4b01ff281df937f6563c190b55313a14e9b1b5ac960003933f0793/sphinx_polyversion-2.0.0.tar.gz", hash = "sha256:ce5d15bbf5d2003aaec9e25c1646ec4f8a91cd55dac89df60ff17bd15630f926", size = 32265, upload-time = "2025-09-25T15:15:13.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/ac/88c719ec04351cd1d56c5faab18e6183b3d82eb5c64a10284feeaadb6ff1/sphinx_polyversion-2.0.0-py3-none-any.whl", hash = "sha256:5455e8a5560d587a0401009196612c98b067138e69556891eb9b8edc547e1327", size = 36628, upload-time = "2025-09-25T15:15:11.939Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Use sphinx-polyversion to build the newest branch of each major version into /v0/, /v1/ and so on, with a switcher.

The root and the old unversioned pages redirect into the latest release, fragment included.

Fix #299.

