### PR TITLE
ci: use uv 0.12.5 on GitHub Actions and Vercel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
         with:
-          version: "0.9.7"
+          version: "0.12.5"
           enable-cache: true
 
       # Release tags come with the checkout, but sphinx-polyversion only

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
       "gh-pages": false
     }
   },
-  "installCommand": "pip3 install uv==0.12.5",
-  "buildCommand": "git fetch --depth=1 \"https://github.com/$VERCEL_GIT_REPO_OWNER/$VERCEL_GIT_REPO_SLUG.git\" '+refs/tags/v*:refs/tags/v*' '+refs/heads/*-rc:refs/heads/*-rc' && LC_ALL=C.UTF-8 uv run sphinx-polyversion poly.py build/html",
+  "installCommand": "curl -LsSf https://astral.sh/uv/0.12.5/install.sh | UV_INSTALL_DIR=.uv UV_NO_MODIFY_PATH=1 sh",
+  "buildCommand": "git fetch --depth=1 \"https://github.com/$VERCEL_GIT_REPO_OWNER/$VERCEL_GIT_REPO_SLUG.git\" '+refs/tags/v*:refs/tags/v*' '+refs/heads/*-rc:refs/heads/*-rc' && LC_ALL=C.UTF-8 ./.uv/uv run sphinx-polyversion poly.py build/html",
   "outputDirectory": "build/html"
 }


### PR DESCRIPTION
The workflow pinned uv 0.9.7, which predates Python 3.14.5 and cannot download it. On Vercel pip refuses to install uv because the image Python is uv-managed (PEP 668): the pinned standalone installer puts it in the repo directory instead.

