### PR TITLE
doc(spec): deprecate the videos key

### DIFF
--- a/docs/standard/example/publiccode.yml
+++ b/docs/standard/example/publiccode.yml
@@ -62,8 +62,6 @@ description:
       - img/sshot1.jpg
       - img/sshot2.jpg
       - img/sshot3.jpg
-    videos:
-      - https://youtube.com/xxxxxxxx
     awards:
       - 1st Price Software of the year
 

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -577,8 +577,8 @@ Screenshots can be of any shape and size; the suggested formats are:
 -  Tablet: 1024x768 @2x
 -  Mobile: 375x667 @2x
 
-Key ``description/[lang]/videos``
-'''''''''''''''''''''''''''''''''
+Key ``description/[lang]/videos`` (*deprecated*)
+''''''''''''''''''''''''''''''''''''''''''''''''
 
 -  Type: array of strings (URLs)
 -  Presence: optional
@@ -591,8 +591,8 @@ hosted on a video sharing website that supports the
 `oEmbed <https://oembed.com>`__ standard; popular options are YouTube
 and Vimeo.
 
-Since videos are an integral part of the documentation, it is
-recommended to publish them with an open license.
+This key is deprecated, link videos from the documentation or the
+website of the software instead.
 
 Key ``description/[lang]/awards``
 '''''''''''''''''''''''''''''''''


### PR DESCRIPTION
The key requires hosting on a third party oEmbed provider, so a catalog that renders it loads third party embeds and their trackers and have to solve that problem independently.

It is also rarely populated. Videos can be linked from the documentation or the website of the software anyway.

