### PR TITLE
doc(spec): deprecate the government scope

### DIFF
--- a/docs/standard/scope-list.rst
+++ b/docs/standard/scope-list.rst
@@ -20,7 +20,7 @@ Valid Tags
 - environment
 - finance-and-economic-development
 - foreign-affairs
-- government
+- government (*deprecated*)
 - healthcare
 - infrastructures
 - justice


### PR DESCRIPTION
Nearly everything described by a publiccode.yml file is government software, so the tag selects nothing when filtering a catalog. 1.0 removes the value.

See #81.

