### PR TITLE
doc(spec): deprecate the localisationReady key

### DIFF
--- a/docs/standard/example/publiccode.minimal.yml
+++ b/docs/standard/example/publiccode.minimal.yml
@@ -34,6 +34,5 @@ maintenance:
     - name: Francesco Rossi
 
 localisation:
-  localisationReady: true
   availableLanguages:
     - en

--- a/docs/standard/example/publiccode.yml
+++ b/docs/standard/example/publiccode.yml
@@ -87,7 +87,6 @@ maintenance:
       phone: "+3923113215112"
 
 localisation:
-  localisationReady: true
   availableLanguages:
     - en
     - it

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -723,15 +723,18 @@ Section ``localisation``
 This section provides an overview of the localization features of the
 software.
 
-Key ``localisation/localisationReady``
-''''''''''''''''''''''''''''''''''''''
+Key ``localisation/localisationReady`` (*deprecated*)
+'''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 -  Type: boolean
--  Presence: mandatory
+-  Presence: optional
 
 If ``true``, the software has infrastructure in place or is otherwise
 designed to be multilingual. It does not need to be available in more
 than one language.
+
+This key is deprecated, use ``localisation/availableLanguages`` to
+state the languages the software is available in.
 
 Key ``localisation/availableLanguages``
 '''''''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
The boolean is basically a duplication of len(availableLanguages) > 1 and it could also describe a contradicting state, for example:

```yaml
localisationReady: false
availableLanguages:
  - it
  - fr
```

