### PR TITLE
doc(spec): deprecate the `unsupportedCountries` key

### DIFF
--- a/docs/standard/example/publiccode.yml
+++ b/docs/standard/example/publiccode.yml
@@ -33,8 +33,6 @@ intendedAudience:
   countries:
     - IT
     - DE
-  unsupportedCountries:
-    - US
 
 description:
   en:

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -378,8 +378,8 @@ i.e. the software explicitly claims compliance with specific processes,
 technologies or laws. All countries are specified using lowercase (*deprecated*)
 or uppercase ISO 3166-1 alpha-2 two-letter country codes.
 
-Key ``intendedAudience/unsupportedCountries``
-'''''''''''''''''''''''''''''''''''''''''''''
+Key ``intendedAudience/unsupportedCountries`` (*deprecated*)
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 -  Type: array of strings
 -  Presence: optional
@@ -388,6 +388,9 @@ This key explicitly marks countries as NOT supported. This might be the
 case if there is a conflict between how software is working and a
 specific law, process or technology. All countries are specified using
 lowercase (*deprecated*) or uppercase ISO 3166-1 alpha-2 two-letter country codes.
+
+This key is deprecated, use ``intendedAudience/countries`` to list the
+countries the software explicitly targets instead.
 
 Key ``intendedAudience/scope``
 ''''''''''''''''''''''''''''''


### PR DESCRIPTION
Not supporting a country is a nearly meaningless concept: any software may conflict with some law somewhere and nobody maintains the complete set. In fact, no publiccode.yml found on the Internet uses the key.

Absence from countries already states that a country is not targeted.

