### PR TITLE
doc(spec): deprecate the single string form of isBasedOn

### DIFF
--- a/docs/standard/example/publiccode.yml
+++ b/docs/standard/example/publiccode.yml
@@ -4,7 +4,8 @@ name: Medusa
 applicationSuite: MegaProductivitySuite
 url: "https://example.com/italia/medusa.git"
 landingURL: "https://example.com/italia/medusa"
-isBasedOn: "https://github.com/italia/otello.git"
+isBasedOn:
+  - "https://github.com/italia/otello.git"
 softwareVersion: "1.0"
 releaseDate: "2017-04-15"
 logo: img/logo.svg

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -83,9 +83,9 @@ download of such an installer.
 Key ``isBasedOn``
 ~~~~~~~~~~~~~~~~~
 
--  Type: string or array of strings
+-  Type: array of strings, or a single string (*deprecated*)
 -  Presence: optional
--  Example: ``"https://github.com/italia/otello.git"``
+-  Example: ``["https://github.com/italia/otello.git"]``
 
 In case this software is a variant or a fork of another software, which
 might or might not contain a ``publiccode.yml`` file, this key will
@@ -93,6 +93,9 @@ contain the ``url`` of the original project(s).
 
 The existence of this key identifies the fork as a software
 variant, descending from the specified repositories.
+
+The single string form is deprecated, use a one element array
+instead.
 
 Key ``softwareVersion``
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The key accepts a bare string or an array.

A one element array covers the single case, and 1.0 will drop the string form.

