### PR TITLE
doc(spec): deprecate the dependsOn/open key

### DIFF
--- a/docs/standard/example/publiccode.yml
+++ b/docs/standard/example/publiccode.yml
@@ -95,14 +95,6 @@ localisation:
     - de
 
 dependsOn:
-  open:
-    - name: MySQL
-      versionMin: "1.1"
-      versionMax: "1.3"
-      optional: true
-    - name: PostgreSQL
-      version: "3.2"
-      optional: true
   proprietary:
     - name: Oracle
       versionMin: "11.4"

--- a/docs/standard/schema.core.rst
+++ b/docs/standard/schema.core.rst
@@ -757,14 +757,19 @@ system-level dependencies that must be installed and maintained
 separately. For instance, a database is a good example of such
 dependencies.
 
-Key ``dependsOn/open``
-''''''''''''''''''''''
+Key ``dependsOn/open`` (*deprecated*)
+'''''''''''''''''''''''''''''''''''''
 
 -  Type: array of ``dependency`` (see below)
 -  Presence: optional
 
 This key contains a list of runtime dependencies that are distributed
 under an open-source license.
+
+This key is deprecated. Open source runtime dependencies are already
+declared in the SBOM or in the package manager manifests, and what
+needs to be installed belongs in the documentation and in the
+deployment scripts.
 
 Key ``dependsOn/proprietary``
 '''''''''''''''''''''''''''''


### PR DESCRIPTION
The SBOM or the package manager manifests already declare the open source dependencies, so the key holds a partial and stale copy. Installation requirements go in the documentation and in the deployment scripts.

