### PR TITLE
fix: preserve query strings in legacy documentation redirects

### DIFF
--- a/poly.py
+++ b/poly.py
@@ -60,7 +60,7 @@ REDIRECT = """<!DOCTYPE html>
 <title>publiccode.yml Standard</title>
 <link rel="canonical" href="{target}">
 <meta http-equiv="refresh" content="0; url={target}">
-<script>location.replace("{target}" + location.hash);</script>
+<script>location.replace("{target}" + location.search + location.hash);</script>
 </head>
 <body>
 <p>Moved to <a href="{target}">{target}</a>.</p>


### PR DESCRIPTION
The legacy redirects append `location.hash` but omit `location.search` , so a link such as `/search.html?q=maintenance` reaches the versioned search page without its search term.

Append the original query before the fragment. The existing relative target, `location.replace` behavior, canonical link and static fallback remain unchanged. No specification content, parser API, dependencies or version-selection behavior changes.

Fixes #363