### PR TITLE
fix: show the text excerpts under the search results

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,5 +1,14 @@
 {% extends '!layout.html' %}
 
+{#- Sphinx 7.2 moved the content root from documentation_options.js to a
+    data attribute on <html>, which the theme's layout does not emit, so
+    the search page fetched its result excerpts from "undefined<page>". -#}
+
+{% block extrahead %}
+{{ super() }}
+<script>document.documentElement.dataset.content_root = "{{ content_root }}";</script>
+{% endblock %}
+
 {% block footer %}
 
 <div class="footer">


### PR DESCRIPTION
The theme does not tell Sphinx's search script where the site root is, so it fetched the pages from a wrong URL and every excerpt was missing.

